### PR TITLE
Donut as the default Pie chart mode

### DIFF
--- a/src/NestedProportionalAreaChart/ScaledCircle.js
+++ b/src/NestedProportionalAreaChart/ScaledCircle.js
@@ -45,6 +45,7 @@ function ScaledCircle({
     <React.Fragment>
       <PieChart
         data={backgroundData}
+        donut={false}
         height={height}
         origin={{ x: cx, y: cy }}
         radius={size}
@@ -57,6 +58,7 @@ function ScaledCircle({
         colorScale={colorScale}
         height={height}
         data={radii.map(v => [v])}
+        donut={false}
         origin={{ x: cx, y: cy }}
         radii={radii}
         standalone={false}

--- a/src/PieChart/index.js
+++ b/src/PieChart/index.js
@@ -21,6 +21,7 @@ function PieChart({
   parts,
   radius,
   radii,
+  responsive,
   standalone,
   theme,
   height,
@@ -38,6 +39,15 @@ function PieChart({
   if (radii && colorScale && colorScale.length > 1) {
     colorScale2 = colorScale.slice(1);
   }
+  const containerProps = Object.assign(
+    {
+      height: height || chart.height,
+      responsive,
+      standalone,
+      width: width || chart.width
+    },
+    parts && parts.container
+  );
   const tooltipProps = (parts && parts.tooltip) || { style: {} };
 
   const startAngle1 = 0;
@@ -71,11 +81,7 @@ function PieChart({
   }
 
   return (
-    <CustomContainer
-      standalone={standalone}
-      height={height || chart.height}
-      width={width || chart.height}
-    >
+    <CustomContainer {...containerProps}>
       <VictoryPie
         standalone={false}
         groupComponent={
@@ -152,6 +158,7 @@ PieChart.propTypes = {
   innerRadius: PropTypes.number,
   padding: PropTypes.oneOf(PropTypes.number, PropTypes.shape({})),
   parts: PropTypes.shape({
+    container: PropTypes.shape({}),
     tooltip: PropTypes.shape({})
   }),
   radius: PropTypes.number,
@@ -163,6 +170,7 @@ PieChart.propTypes = {
    * (if any).
    */
   radii: PropTypes.arrayOf(PropTypes.number),
+  responsive: PropTypes.bool,
   standalone: PropTypes.bool,
   theme: PropTypes.shape({
     pie: PropTypes.shape({})
@@ -181,6 +189,7 @@ PieChart.defaultProps = {
   parts: undefined,
   radius: undefined,
   radii: undefined,
+  responsive: true,
   standalone: true,
   theme: undefined,
   width: undefined

--- a/src/PieChart/index.js
+++ b/src/PieChart/index.js
@@ -7,7 +7,6 @@ import withVictoryTheme from '../styles/withVictoryTheme';
 import CustomContainer from '../CustomContainer';
 import PieLabel from './PieLabel';
 
-const DEFAULT_DONUT_INNER_RADIUS = 75; // in degrees
 const computeRadii = (width, height, padding, groupSpacing = 0) => {
   const radius = Helpers.getRadius({ width, height, padding });
   return [radius - groupSpacing / 2];
@@ -22,7 +21,7 @@ function PieChart({
   parts,
   radius,
   radii,
-  standalone = true,
+  standalone,
   theme,
   height,
   width,
@@ -51,13 +50,6 @@ function PieChart({
     endAngle1 = -180; // Half circle, counter-clockwise
     [data1, data2] = data; // Assume data[2] is also Array
   }
-  let innerRadius = 0;
-  if (donut || chart.donut) {
-    innerRadius =
-      suggestedInnerRadius && suggestedInnerRadius > 0
-        ? suggestedInnerRadius
-        : DEFAULT_DONUT_INNER_RADIUS;
-  }
   // Only include groupSpacing if in comparison mode
   const computedGroupSpacing = data2 ? groupSpacing || chart.groupSpacing : 0;
   const computedRadii =
@@ -70,6 +62,13 @@ function PieChart({
           padding || chart.padding,
           computedGroupSpacing
         ));
+  let innerRadius = 0;
+  if (donut || (typeof donut === 'undefined' && chart.donut)) {
+    innerRadius =
+      suggestedInnerRadius && suggestedInnerRadius > 0
+        ? suggestedInnerRadius
+        : Math.min.apply(null, computedRadii) * chart.donutRatio;
+  }
 
   return (
     <CustomContainer
@@ -182,7 +181,7 @@ PieChart.defaultProps = {
   parts: undefined,
   radius: undefined,
   radii: undefined,
-  standalone: undefined,
+  standalone: true,
   theme: undefined,
   width: undefined
 };

--- a/src/styles/createVictoryTheme.js
+++ b/src/styles/createVictoryTheme.js
@@ -68,7 +68,10 @@ export default function createVictoryTheme(chartOptions) {
     chart.comparisonBar
   );
   // Customize chart pie props
-  chart.pie = Object.assign({ donut: false, groupSpacing: 8 }, chart.pie);
+  chart.pie = Object.assign(
+    { donut: true, donutRatio: 0.6, groupSpacing: 4 },
+    chart.pie
+  );
   // Customize chart proportionalArea props off of chart area props
   chart.proportionalArea = Object.assign(
     { reference: defaultReference },

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -274,6 +274,8 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
         width={number('width', 500)}
         height={number('height', 500)}
         padding={number('padding', 75)}
+        responsive={boolean('responsive', true)}
+        standalone={boolean('standalone', true)}
       />
     </div>
   ))

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -263,7 +263,7 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
   .add('Default', () => (
     <div>
       <PieChart
-        donut={boolean('donut', false)}
+        donut={boolean('donut', true)}
         data={object('data', [
           { x: 'A', y: 1 },
           { x: 'B', y: 2 },
@@ -280,8 +280,8 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
   .add('Comparison', () => (
     <div>
       <PieChart
-        donut={boolean('donut', false)}
-        groupSpacing={number('groupSpacing', 8)}
+        donut={boolean('donut', true)}
+        groupSpacing={number('groupSpacing', 4)}
         data={object('data', [
           [
             { x: 'A', y: 1, label: ['A\n \nDar es Salaam 1'] },


### PR DESCRIPTION
## Description

Set `donut` as the default pie chart mode.

 - [x] `donut` parameter should default to true in theme,
 - [x] Add `donutRatio` variable to `theme` to control default `innerRadius` of donut chart, and
 - [x] Updated Nested circle chart to work with the above. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

![Peek 2019-08-20 10-10](https://user-images.githubusercontent.com/1779590/63325485-e2a8b880-c332-11e9-98e4-d77f385d0c7c.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation