### PR TITLE
Fix/horizontal chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforafrica/hurumap-ui",
-  "version": "0.1.0-rc.12",
+  "version": "0.1.0-rc.13",
   "description": "HURUmap charts, map and other components.",
   "repository": "https://github.com/CodeForAfrica/HURUmap-UI.git",
   "author": "Code for Africa <hello@codeforafrica.org> (https://codeforafrica.org)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforafrica/hurumap-ui",
-  "version": "0.1.0-rc.13",
+  "version": "0.1.0-rc.14",
   "description": "HURUmap charts, map and other components.",
   "repository": "https://github.com/CodeForAfrica/HURUmap-UI.git",
   "author": "Code for Africa <hello@codeforafrica.org> (https://codeforafrica.org)",

--- a/src/BarChart/index.js
+++ b/src/BarChart/index.js
@@ -10,6 +10,7 @@ import BarLabel from './BarLabel';
 
 function BarChart({
   barWidth,
+  labelWidth: propLabelWidth,
   data: d,
   domain,
   domainPadding,
@@ -23,7 +24,7 @@ function BarChart({
   ...props
 }) {
   const {
-    axis: { labelWidth: defaultLabelWidth },
+    axis: { labelWidth: themeLabelWidth },
     bar: chart,
     group: groupChart
   } = theme;
@@ -32,8 +33,8 @@ function BarChart({
   }
 
   const groupData = Array.isArray(d[0]) ? d : [d];
-  let labelWidth = defaultLabelWidth;
-  if (groupData.length > 1) {
+  let labelWidth = propLabelWidth || themeLabelWidth;
+  if (groupData.length > 1 && !propLabelWidth) {
     const barSpacing = offset || barWidth;
     if (barSpacing) {
       labelWidth = barSpacing * groupData.length;
@@ -120,6 +121,7 @@ BarChart.propTypes = {
     })
   ),
   barWidth: PropTypes.number,
+  labelWidth: PropTypes.number,
   domain: PropTypes.oneOfType([PropTypes.number, PropTypes.shape({})]),
   domainPadding: PropTypes.oneOfType([PropTypes.number, PropTypes.shape({})]),
   height: PropTypes.number,
@@ -144,6 +146,7 @@ BarChart.propTypes = {
 
 BarChart.defaultProps = {
   barWidth: undefined,
+  labelWidth: undefined,
   data: undefined,
   domain: undefined,
   domainPadding: undefined,


### PR DESCRIPTION
## Description

Allow `propLabelWidth` to override any theme definened width or auto calculated labelWidth.
This will allow horizontal charts to have longer width labels.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation