### PR TITLE
Add text wrapping to VictoryLabel & Use it for Legend

### DIFF
--- a/src/Label.js
+++ b/src/Label.js
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { VictoryLabel } from 'victory';
+
+const canvas = document.createElement('canvas');
+
+/**
+ * While VictoryLabel can handle array of strings, it can not handle wrapping
+ * for a long string. We need this component to help breakdown long strings
+ * but yet, reuse everything VictoryLabel offers: styling, etc.
+ *
+ * @param {*} param0 .
+ */
+function Label({ text: originalText, width, ...props }) {
+  const [text, setText] = useState();
+  useEffect(() => {
+    if (originalText && width) {
+      const words = originalText.split(/\s+/).reverse();
+      const textLines = [];
+      let word = words.pop();
+      let line = [];
+
+      while (word) {
+        line.push(word);
+        const textContent = line.join(' ');
+        const { width: measuredWidth } = Label.canvasContext.measureText(
+          textContent
+        );
+        if (measuredWidth > width) {
+          line.pop();
+          if (line.length > 0) {
+            textLines.push(line.join(' '));
+            line = [word];
+          } else {
+            // single, long word
+            textLines.push(word);
+          }
+        }
+        word = words.pop();
+      }
+      // Any word(s) whose length was still < width
+      if (line.length > 0) {
+        textLines.push(line.join(' '));
+      }
+      setText(textLines.join('\n'));
+    }
+  }, [originalText, width]);
+
+  return <VictoryLabel text={text} {...props} />;
+}
+
+// Creating canvas and context is any expensive operation so lets reuse the
+// context.
+Label.canvasContext = canvas.getContext('2d');
+
+Label.propTypes = {
+  text: PropTypes.string,
+  width: PropTypes.number
+};
+
+Label.defaultProps = {
+  text: undefined,
+  width: undefined
+};
+
+export default Label;

--- a/src/Label.js
+++ b/src/Label.js
@@ -15,8 +15,8 @@ const canvas = document.createElement('canvas');
 function Label({ text: originalText, width, ...props }) {
   const [text, setText] = useState(originalText);
   useEffect(() => {
-    if (originalText && width) {
-      const words = originalText.split(/\s+/).reverse();
+    const wrap = textToWrap => {
+      const words = textToWrap.split(/\s+/).reverse();
       const textLines = [];
       let word = words.pop();
       let line = [];
@@ -43,15 +43,21 @@ function Label({ text: originalText, width, ...props }) {
       if (line.length > 0) {
         textLines.push(line.join(' '));
       }
-      setText(textLines.join('\n'));
+      return textLines.join('\n');
+    };
+    if (originalText && width) {
+      // Preserve any `\n` in original text string (if any)
+      const textToWrap = Array.isArray(originalText)
+        ? originalText
+        : originalText.split('\n');
+      setText(textToWrap.map(wrap).join('\n'));
     }
   }, [originalText, width]);
 
   return <VictoryLabel text={text} {...props} />;
 }
 
-// Creating canvas and context is any expensive operation so lets reuse the
-// context.
+// Lets reuse canvas context.
 Label.canvasContext = canvas.getContext('2d');
 
 Label.propTypes = {

--- a/src/Label.js
+++ b/src/Label.js
@@ -5,6 +5,19 @@ import { VictoryLabel } from 'victory';
 
 const canvas = document.createElement('canvas');
 
+const getFont = (style = {}) => {
+  const { font, fontFamily, fontSize } = style;
+  if (font) {
+    return font;
+  }
+  // font requires at least family and size: https://developer.mozilla.org/en-US/docs/Web/CSS/font#Syntax
+  if (fontFamily && fontSize) {
+    const unit = typeof fontSize === 'number' ? 'px' : '';
+    return `${fontSize}${unit} ${fontFamily}`;
+  }
+  return undefined;
+};
+
 /**
  * While VictoryLabel can handle array of strings, it can not handle wrapping
  * for a long string. We need this component to help breakdown long strings
@@ -12,7 +25,7 @@ const canvas = document.createElement('canvas');
  *
  * @param {*} param0 .
  */
-function Label({ text: originalText, width, ...props }) {
+function Label({ text: originalText, width, style, ...props }) {
   const [text, setText] = useState(originalText);
   useEffect(() => {
     const wrap = textToWrap => {
@@ -20,6 +33,10 @@ function Label({ text: originalText, width, ...props }) {
       const textLines = [];
       let word = words.pop();
       let line = [];
+      const font = getFont(style);
+      if (font) {
+        Label.canvasContext.font = font;
+      }
 
       while (word) {
         line.push(word);
@@ -52,20 +69,22 @@ function Label({ text: originalText, width, ...props }) {
         : originalText.split('\n');
       setText(textToWrap.map(wrap).join('\n'));
     }
-  }, [originalText, width]);
+  }, [originalText, style, width]);
 
-  return <VictoryLabel text={text} {...props} />;
+  return <VictoryLabel style={style} text={text} {...props} />;
 }
 
 // Lets reuse canvas context.
 Label.canvasContext = canvas.getContext('2d');
 
 Label.propTypes = {
+  style: PropTypes.shape({}),
   text: PropTypes.string,
   width: PropTypes.number
 };
 
 Label.defaultProps = {
+  style: undefined,
   text: undefined,
   width: undefined
 };

--- a/src/Label.js
+++ b/src/Label.js
@@ -13,7 +13,7 @@ const canvas = document.createElement('canvas');
  * @param {*} param0 .
  */
 function Label({ text: originalText, width, ...props }) {
-  const [text, setText] = useState();
+  const [text, setText] = useState(originalText);
   useEffect(() => {
     if (originalText && width) {
       const words = originalText.split(/\s+/).reverse();

--- a/src/PieChart/LegendLabel.js
+++ b/src/PieChart/LegendLabel.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { VictoryTooltip } from 'victory';
 
 import PieLabel from './PieLabel';
-import Label from '../Label';
 
 /**
  * VictoryLegend only uses `name` for displaying the key. This component
@@ -12,12 +11,13 @@ import Label from '../Label';
  *
  * @param {*} props .
  */
+// while we need `width` for the label, we don't need it for tooltip
 function LegendLabel({ width, ...props }) {
   const { colorScale, data, datum, index } = props;
 
   return (
     <g>
-      <Label width={width} {...props} />
+      <PieLabel width={width} {...props} />
       <VictoryTooltip
         {...props}
         datum={Object.assign({ _x: index + 1 }, datum)}

--- a/src/PieChart/LegendLabel.js
+++ b/src/PieChart/LegendLabel.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { VictoryTooltip } from 'victory';
 
 import PieLabel from './PieLabel';
+import Label from '../Label';
 
 /**
  * VictoryLegend only uses `name` for displaying the key. This component
@@ -11,12 +12,12 @@ import PieLabel from './PieLabel';
  *
  * @param {*} props .
  */
-function LegendLabel(props) {
+function LegendLabel({ width, ...props }) {
   const { colorScale, data, datum, index } = props;
 
   return (
     <g>
-      <PieLabel {...props} />
+      <Label width={width} {...props} />
       <VictoryTooltip
         {...props}
         datum={Object.assign({ _x: index + 1 }, datum)}
@@ -37,14 +38,16 @@ LegendLabel.propTypes = {
     })
   ),
   datum: PropTypes.arrayOf(PropTypes.shape({})),
-  index: PropTypes.number
+  index: PropTypes.number,
+  width: PropTypes.number
 };
 
 LegendLabel.defaultProps = {
   data: undefined,
   colorScale: undefined,
   datum: undefined,
-  index: undefined
+  index: undefined,
+  width: undefined
 };
 
 export default LegendLabel;

--- a/src/PieChart/PieLabel.js
+++ b/src/PieChart/PieLabel.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { VictoryLabel } from 'victory';
-
 import withVictoryTheme from '../styles/withVictoryTheme';
+import Label from '../Label';
 
 function PieLabel({
   colorScale = [],
@@ -22,7 +21,7 @@ function PieLabel({
       )
     : originalStyle;
 
-  return <VictoryLabel style={style} {...props} />;
+  return <Label style={style} {...props} />;
 }
 
 PieLabel.propTypes = {

--- a/src/PieChart/index.js
+++ b/src/PieChart/index.js
@@ -162,17 +162,6 @@ function PieChart({
 
   return (
     <CustomContainer {...containerProps}>
-      {legendProps && (
-        <VictoryLegend
-          standalone={false}
-          labelComponent={
-            <LegendLabel colorScale={colorScale1} width={legendWidth} />
-          }
-          {...legendProps}
-          x={chartWidth}
-          y={paddingTop}
-        />
-      )}
       {donut && (
         <DonutLabel
           data={donutLabelData}
@@ -228,6 +217,17 @@ function PieChart({
           width={width}
           labelComponent={labelComponent2}
           {...props}
+        />
+      )}
+      {legendProps && (
+        <VictoryLegend
+          standalone={false}
+          labelComponent={
+            <LegendLabel colorScale={colorScale1} width={legendWidth} />
+          }
+          {...legendProps}
+          x={chartWidth}
+          y={paddingTop}
         />
       )}
     </CustomContainer>

--- a/src/PieChart/index.js
+++ b/src/PieChart/index.js
@@ -166,11 +166,7 @@ function PieChart({
         <VictoryLegend
           standalone={false}
           labelComponent={
-            <LegendLabel
-              colorScale={colorScale1}
-              width={legendWidth}
-              {...tooltipProps}
-            />
+            <LegendLabel colorScale={colorScale1} width={legendWidth} />
           }
           {...legendProps}
           x={chartWidth}

--- a/src/PieChart/index.js
+++ b/src/PieChart/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Helpers, VictoryPie, VictoryTooltip, VictoryLegend } from 'victory';
 
 import withVictoryTheme from '../styles/withVictoryTheme';
+
 import CustomContainer from '../CustomContainer';
 import DonutLabel from './DonutLabel';
 import LegendLabel from './LegendLabel';
@@ -13,6 +14,7 @@ const computeRadii = (width, height, padding, groupSpacing = 0) => {
   const radius = Helpers.getRadius({ width, height, padding });
   return [radius - groupSpacing / 2];
 };
+
 function PieChart({
   colorScale,
   data,
@@ -22,6 +24,7 @@ function PieChart({
   innerRadius: suggestedInnerRadius,
   legend,
   legendWidth: suggestedLegendWidth,
+  origin: suggestedOrigin,
   padding: suggestedPadding,
   parts,
   radius,
@@ -106,6 +109,10 @@ function PieChart({
         : Math.min.apply(null, computedRadii) * chart.donutRatio;
   }
   const paddingTop = padding.top || 0;
+  const origin = suggestedOrigin || {
+    x: chartWidth / 2,
+    y: paddingTop + chartRadius
+  };
   const donutLabelData = data2 ? data[donutLabelKey.dataIndex] : data1;
   const { style: suggestedHeightStyle } = props;
   const donutLabelStyle = Object.assign(
@@ -138,7 +145,7 @@ function PieChart({
       orientation="top"
       pointerLength={0}
       width={chartInnerRadius * 2}
-      x={width / 2}
+      x={origin.x}
       y={paddingTop + chartRadius + chartInnerRadius}
     />
   ) : (
@@ -169,7 +176,7 @@ function PieChart({
           sortKey={donutLabelKey.sortKey}
           style={donutLabelStyle}
           text={data1[0].label}
-          x={width / 2}
+          x={origin.x}
           y={paddingTop + chartRadius}
         />
       )}
@@ -186,7 +193,7 @@ function PieChart({
         endAngle={endAngle1}
         innerRadius={chartInnerRadius}
         labelRadius={labelRadius}
-        origin={{ x: width / 2, y: paddingTop + chartRadius }}
+        origin={origin}
         radius={computedRadii[0]}
         startAngle={startAngle1}
         theme={theme}
@@ -209,7 +216,7 @@ function PieChart({
           }
           innerRadius={chartInnerRadius}
           labelRadius={labelRadius}
-          origin={{ x: width / 2, y: paddingTop + chartRadius }}
+          origin={origin}
           radius={computedRadii[1 % computedRadii.length]}
           startAngle={startAngle2}
           theme={theme}
@@ -258,6 +265,10 @@ PieChart.propTypes = {
   innerRadius: PropTypes.number,
   legend: PropTypes.arrayOf(PropTypes.shape({})),
   legendWidth: PropTypes.number,
+  origin: PropTypes.shape({
+    x: PropTypes.number,
+    y: PropTypes.number
+  }),
   padding: PropTypes.oneOfType([PropTypes.number, PropTypes.shape({})]),
   parts: PropTypes.shape({
     legend: PropTypes.shape({}),
@@ -294,6 +305,7 @@ PieChart.defaultProps = {
   innerRadius: undefined,
   legend: undefined,
   legendWidth: undefined,
+  origin: undefined,
   padding: undefined,
   parts: undefined,
   radius: undefined,

--- a/src/PieChart/index.js
+++ b/src/PieChart/index.js
@@ -166,7 +166,11 @@ function PieChart({
         <VictoryLegend
           standalone={false}
           labelComponent={
-            <LegendLabel colorScale={colorScale1} {...tooltipProps} />
+            <LegendLabel
+              colorScale={colorScale1}
+              width={legendWidth}
+              {...tooltipProps}
+            />
           }
           {...legendProps}
           x={chartWidth}

--- a/src/PieChart/index.js
+++ b/src/PieChart/index.js
@@ -146,7 +146,7 @@ function PieChart({
       pointerLength={0}
       width={chartInnerRadius * 2}
       x={origin.x}
-      y={paddingTop + chartRadius + chartInnerRadius}
+      y={origin.y + chartInnerRadius}
     />
   ) : (
     <VictoryTooltip
@@ -177,7 +177,7 @@ function PieChart({
           style={donutLabelStyle}
           text={data1[0].label}
           x={origin.x}
-          y={paddingTop + chartRadius}
+          y={origin.y}
         />
       )}
       <VictoryPie

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -305,12 +305,13 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
             }
           },
           legend: {
+            rowGutter: number('Legend row spacing', 20),
             style: { labels: { fontSize: 20, fontWeight: 'bold' } }
           }
         }}
         legend={[
-          { name: 'Female', label: 'Female: 22%' },
-          { name: 'Male', label: 'Male: 78%' }
+          { name: 'A very, very, very, very long legend name', label: 'Female: 22%' },
+          { name: 'Short one', label: 'Male: 78%' }
         ]}
         responsive={boolean('responsive', true)}
         standalone={boolean('standalone', true)}

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -320,7 +320,10 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
             name: 'A very, very, very, very long legend name',
             label: 'Female: 22%'
           },
-          { name: 'Short one', label: 'Male: 78%' }
+          {
+            name: 'Short one',
+            label: 'Long tooltip label should appear above chart: 78%'
+          }
         ]}
         legendWidth={number('Legend width', 100)}
         responsive={boolean('responsive', true)}

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -297,7 +297,7 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
         ])}
         width={number('width', 500)}
         height={number('height', 500)}
-        padding={number('padding', 100)}
+        padding={number('padding', 0)}
         origin={object('origin', { x: 200, y: 200 })}
         parts={{
           tooltip: {
@@ -363,7 +363,7 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
         ])}
         width={number('width', 500)}
         height={number('height', 500)}
-        padding={number('padding', 100)}
+        padding={number('padding', 0)}
       />
     </div>
   ));

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -306,13 +306,23 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
           },
           legend: {
             rowGutter: number('Legend row spacing', 20),
-            style: { labels: { fontSize: 20, fontWeight: 'bold' } }
+            style: {
+              labels: object('Legend style', {
+                fontFamily: 'Arial',
+                fontSize: 20,
+                fontWeight: 'bold'
+              })
+            }
           }
         }}
         legend={[
-          { name: 'A very, very, very, very long legend name', label: 'Female: 22%' },
+          {
+            name: 'A very, very, very, very long legend name',
+            label: 'Female: 22%'
+          },
           { name: 'Short one', label: 'Male: 78%' }
         ]}
+        legendWidth={100}
         responsive={boolean('responsive', true)}
         standalone={boolean('standalone', true)}
         style={{

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -298,6 +298,7 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
         width={number('width', 500)}
         height={number('height', 500)}
         padding={number('padding', 100)}
+        origin={object('origin', { x: 200, y: 200 })}
         parts={{
           tooltip: {
             style: {

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -322,7 +322,7 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
           },
           { name: 'Short one', label: 'Male: 78%' }
         ]}
-        legendWidth={100}
+        legendWidth={number('Legend width', 100)}
         responsive={boolean('responsive', true)}
         standalone={boolean('standalone', true)}
         style={{


### PR DESCRIPTION
## Description

While very capable, `VictoryLabel` doesn't support text wrapping. This PR adds a custom `Label` component built on top of `VictoryLabel` that wraps text _before_ passing it to `VictoryLabel`.

  - [x] Add `Label` component capable of text-wrapping,
  - [x] Update `PieChart` legend to use the `Label` component,
  - [x] Revert the automatic calculation of `PieChart` `origin`, and
  - [x] Arrange components to ensure legend tooltip appears at the very top.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1779590/64422888-cdab8380-d0ad-11e9-8377-244c2da3c9fc.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation