### PR TITLE
Fix SVG Blockloader Breaking in Chrome

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.8
+current_version = 0.1.9
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.9
+current_version = 0.1.8
 commit = True
 tag = True
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforafrica/hurumap-ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "HURUmap charts, map and other components.",
   "repository": "https://github.com/CodeForAfrica/HURUmap-UI.git",
   "author": "Code for Africa <hello@codeforafrica.org> (https://codeforafrica.org)",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lodash": "^4.17.14",
     "prop-types": "^15.7.2",
     "react-content-loader": "^4.2.2",
+    "shortid": "^2.2.15",
     "victory": "^32.3.1"
   },
   "peerDependencies": {

--- a/src/BarChart/BarLabel.js
+++ b/src/BarChart/BarLabel.js
@@ -19,8 +19,11 @@ function BarLabel({
       <Tooltip
         {...tooltipProps}
         datum={datum}
-        // eslint-disable-next-line no-underscore-dangle
-        text={(data && datum && data[datum._x - 1].tooltip) || text}
+        text={
+          // eslint-disable-next-line no-underscore-dangle
+          (data && datum && data[datum._x - 1] && data[datum._x - 1].tooltip) ||
+          text
+        }
         x={x}
         y={y}
         // eslint-disable-next-line react/prop-types, no-underscore-dangle
@@ -32,9 +35,13 @@ function BarLabel({
 
 BarLabel.propTypes = {
   datum: PropTypes.shape({ _x: PropTypes.number }),
-  text: PropTypes.string,
+  text: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   tooltipProps: PropTypes.shape({
-    data: PropTypes.shape({})
+    data: PropTypes.arrayOf(
+      PropTypes.shape({
+        tooltip: PropTypes.string
+      })
+    )
   }).isRequired,
   x: PropTypes.number,
   y: PropTypes.number

--- a/src/BlockLoader.js
+++ b/src/BlockLoader.js
@@ -18,12 +18,12 @@ BlockLoader.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]),
-  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  width: PropTypes.number,
+  height: PropTypes.number
 };
 
 BlockLoader.defaultProps = {
   children: null,
-  width: '100%',
-  height: '100%'
+  width: -1,
+  height: -1
 };

--- a/src/BlockLoader.js
+++ b/src/BlockLoader.js
@@ -24,6 +24,6 @@ BlockLoader.propTypes = {
 
 BlockLoader.defaultProps = {
   children: null,
-  width: -1,
-  height: -1
+  width: undefined,
+  height: undefined
 };

--- a/src/ChartContainer/index.js
+++ b/src/ChartContainer/index.js
@@ -202,7 +202,7 @@ function ChartContainer({
           justify="flex-end"
         >
           {onClickShare && (
-            <BlockLoader loading={loading} width="2.5rem" height="2.5rem">
+            <BlockLoader loading={loading} width={40} height={40}>
               <ButtonBase
                 className={classes.button}
                 onClick={() => onClickShare(getReferenceObject(shareButtonRef))}
@@ -214,7 +214,7 @@ function ChartContainer({
           )}
 
           {onClickDownload && (
-            <BlockLoader loading={loading} width="2.5rem" height="2.5rem">
+            <BlockLoader loading={loading} width={40} height={40}>
               <ButtonBase
                 className={classes.button}
                 onClick={() =>
@@ -228,7 +228,7 @@ function ChartContainer({
           )}
 
           {onClickEmbed && (
-            <BlockLoader loading={loading} width="2.5rem" height="2.5rem">
+            <BlockLoader loading={loading} width={40} height={40}>
               <ButtonBase
                 className={classes.button}
                 onClick={() => onClickEmbed(getReferenceObject(embedButtonRef))}
@@ -240,7 +240,7 @@ function ChartContainer({
           )}
 
           {onClickCompare && (
-            <BlockLoader loading={loading} width="2.5rem" height="2.5rem">
+            <BlockLoader loading={loading} width={40} height={40}>
               <ButtonBase
                 className={classes.button}
                 onClick={() =>
@@ -254,7 +254,7 @@ function ChartContainer({
           )}
 
           {onClickData && (
-            <BlockLoader loading={loading} width="2.5rem" height="2.5rem">
+            <BlockLoader loading={loading} width={40} height={40}>
               <ButtonBase
                 className={classes.button}
                 onClick={() => onClickData(getReferenceObject(dataButtonRef))}
@@ -275,7 +275,9 @@ function ChartContainer({
         className={classes.content}
         style={{ width: content.width, height: content.height }}
       >
-        <div style={{ height: '100%' }}>
+        {/* Set width 100% only when loading to allow Chart to define its own width 
+            otherwise a chart with a small width will scale and look large. */}
+        <div style={{ width: loading && '100%', height: '100%' }}>
           <BlockLoader loading={loading}>{children}</BlockLoader>
           <TypographyLoader
             loading={loading}
@@ -335,7 +337,7 @@ src="https://tanzania.hurumap.org/embed/iframe.html?geoID=region-11&geoVersion=2
 frameBorder="0"
 width="100%"
 height="300"
-style="margin: 1em; max-width: 300px;"
+style="margin: 1em; max-width: 18.75rem;"
 />
 <script src="https://tanzania.hurumap.org/static/js/embed.chart.make.js" />`
   },

--- a/src/ContentLoader.js
+++ b/src/ContentLoader.js
@@ -1,20 +1,36 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ContentLoader from 'react-content-loader';
 
 export default function CustomContentLoader({
+  id,
   children,
   height,
   width,
   ...props
 }) {
+  const [dimmension, setDimension] = useState({
+    width: width === -1 ? 0 : width,
+    height: height === -1 ? 0 : height
+  });
+  useEffect(() => {
+    const rect = document
+      .getElementById(id)
+      .parentElement.getBoundingClientRect();
+    setDimension({
+      width: width === -1 ? rect.width : width,
+      height: height === -1 ? rect.height : height
+    });
+  }, [id, width, height]);
+
   return (
     <ContentLoader
+      id={id}
       primaryOpacity={0.01}
       secondaryOpacity={0.1}
-      width="100%"
-      height="100%"
-      viewBox={`0 0 ${width} ${height}`}
+      width={dimmension.width}
+      height={dimmension.height}
+      viewBox={`0 0 ${dimmension.width} ${dimmension.height}`}
       style={{ width, height }}
       {...props}
     >
@@ -24,15 +40,20 @@ export default function CustomContentLoader({
 }
 
 CustomContentLoader.propTypes = {
+  id: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired,
-  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  width: PropTypes.number,
+  height: PropTypes.number
 };
 
 CustomContentLoader.defaultProps = {
-  width: '100%',
-  height: '100%'
+  id:
+    Math.random()
+      .toString(36)
+      .substring(2) + Date.now().toString(36),
+  width: -1,
+  height: -1
 };

--- a/src/ContentLoader.js
+++ b/src/ContentLoader.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ContentLoader from 'react-content-loader';
+import shortid from 'shortid';
 
 export default function CustomContentLoader({
   id,
@@ -50,10 +51,7 @@ CustomContentLoader.propTypes = {
 };
 
 CustomContentLoader.defaultProps = {
-  id:
-    Math.random()
-      .toString(36)
-      .substring(2) + Date.now().toString(36),
+  id: shortid.generate(),
   width: undefined,
   height: undefined
 };

--- a/src/ContentLoader.js
+++ b/src/ContentLoader.js
@@ -10,16 +10,16 @@ export default function CustomContentLoader({
   ...props
 }) {
   const [dimmension, setDimension] = useState({
-    width: width === -1 ? 0 : width,
-    height: height === -1 ? 0 : height
+    width: width === undefined ? 0 : width,
+    height: height === undefined ? 0 : height
   });
   useEffect(() => {
     const rect = document
       .getElementById(id)
       .parentElement.getBoundingClientRect();
     setDimension({
-      width: width === -1 ? rect.width : width,
-      height: height === -1 ? rect.height : height
+      width: width === undefined ? rect.width : width,
+      height: height === undefined ? rect.height : height
     });
   }, [id, width, height]);
 
@@ -54,6 +54,6 @@ CustomContentLoader.defaultProps = {
     Math.random()
       .toString(36)
       .substring(2) + Date.now().toString(36),
-  width: -1,
-  height: -1
+  width: undefined,
+  height: undefined
 };

--- a/src/InsightContainer/index.js
+++ b/src/InsightContainer/index.js
@@ -161,7 +161,7 @@ function InsightContainer({
           alignItems="flex-start"
           justify="center"
         >
-          <BlockLoader loading={loading} height="2.5rem">
+          <BlockLoader loading={loading} height={40}>
             <Actions
               onShare={handleShare}
               onDownload={handleDownload}

--- a/src/MapIt/index.js
+++ b/src/MapIt/index.js
@@ -302,7 +302,7 @@ function MapIt({
     <Fragment>
       {!featuresToDraw && (
         <div className={classes.root}>
-          <BlockLoader loading width="100%" height="100%" />
+          <BlockLoader loading />
         </div>
       )}
       <div

--- a/src/WrapLabel/index.js
+++ b/src/WrapLabel/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import shortid from 'shortid';
 
 import wrapSVGText from './wrapSVGText';
 
@@ -12,14 +13,9 @@ function WrapLabel({ width, text, x, y, style, transform, textAnchor }) {
     }
   }, [text, width, x]);
 
-  const uniqueId =
-    Math.random()
-      .toString(36)
-      .substring(2) + Date.now().toString(36);
-
   return (
     <text
-      key={uniqueId}
+      key={shortid.generate()}
       ref={node => {
         ref.current = node;
       }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6715,6 +6715,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.0.tgz#3de3dbd68cfb2f3bd52550e2bfd439cf75040eb2"
+  integrity sha512-g5WwS+p6Cm+zQhO2YOpRbQThZVnNb7DDq74h8YDCLfAGynrEOrbx2E16dc8ciENiP1va5sqaAruqn2sN+xpkWg==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -8797,6 +8802,13 @@ shelljs@^0.8.1, shelljs@^0.8.3:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shortid@^2.2.15:
+  version "2.2.15"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
+  integrity sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==
+  dependencies:
+    nanoid "^2.1.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
## Description

The skeleton loader is and svg which requires pixel values.
This PR ensure px values are used since chrome is strict and was breaking.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots

Issue:
<img width="1174" alt="Screen Shot 2019-09-09 at 2 32 23 PM" src="https://user-images.githubusercontent.com/4308339/64530543-12395800-d316-11e9-8caf-2dd40232875b.png">

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation