### PR TITLE
[Chore] Switch publish and deploy to single `yarn version` command

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,0 @@
-[bumpversion]
-current_version = 0.1.10
-commit = True
-tag = True
-
-[bumpversion:file:package.json]
-

--- a/README.md
+++ b/README.md
@@ -25,13 +25,10 @@ If you'd like to contribute to sensors.AFRICA, check out the [CONTRIBUTING.md](.
 
 ## Publish A New Release
 
-To publish a new release, we use the excellent [bumpversion](https://pypi.org/project/bumpversion/) package.
-Install it and then run;
+To publish a new release, we use the excellent [yarn version](https://yarnpkg.com/lang/en/docs/cli/version/) cli command, configured to both publish to npm as well as deploy storybook to GitHub pages.
 
 ```
-bumpversion patch
-git push --tags
-npm publish
+yarn version
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "main": "dist/index.js",
   "scripts": {
     "preversion": "yarn lint && yarn build",
-    "postversion": "git push --tags && yarn publish --access public . --new-version $npm_package_version && git push && echo \"Successfully released version $npm_package_version!\"",
+    "postversion": "git push --tags && yarn publish --access public --new-version $npm_package_version . && git push && echo \"Successfully released version $npm_package_version!\"",
     "postpublish": "yarn deploy",
     "lint": "yarn eslint --fix --ignore-path './.gitignore' --ext '.js,.json,.md' './'",
     "lint-staged": "yarn eslint --fix",


### PR DESCRIPTION
## Description

We currently have separate tools and commands to bump `package.json` version and commit, and to publish to npm. This PR brings the whole version/publish/deploy process under a single command; `yarn version`.

 + No need for external dependencies,
 + Updated of version, committing of changed `package.json`, pushing of tags,  as well as deploying of storybook happens in a single command.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Screenshots

![Screenshot from 2019-09-12 09-12-20](https://user-images.githubusercontent.com/1779590/64759007-b56cb600-d53e-11e9-9aa6-4b9998b11d43.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation