### PR TITLE
Improve Insight Chart Container Download/Share Actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@material-ui/core": "^4.3.2",
     "@material-ui/styles": "^4.3.0",
     "dequal": "^1.0.0",
+    "dom-to-image": "^2.6.0",
     "geojson": "^0.5.0",
     "leaflet": "^1.5.1",
     "lodash": "^4.17.14",

--- a/src/InsightContainer/index.js
+++ b/src/InsightContainer/index.js
@@ -130,13 +130,15 @@ function InsightContainer({
   };
 
   const defaultHandleDownload = (e, dataUrl) => {
-    const link = document.createElement('a');
-    link.download = `${title}.png`;
-    link.href = dataUrl;
+    if (dataUrl) {
+      const link = document.createElement('a');
+      link.download = `${title}.png`;
+      link.href = dataUrl;
 
-    document.body.appendChild(link); // Firefox requires this
-    link.click();
-    document.body.removeChild(link);
+      document.body.appendChild(link); // Firefox requires this
+      link.click();
+      document.body.removeChild(link);
+    }
   };
 
   const handleDownload = handleDownloadProp || defaultHandleDownload;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3766,6 +3766,11 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom-to-image@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/dom-to-image/-/dom-to-image-2.6.0.tgz#8a503608088c87b1c22f9034ae032e1898955867"
+  integrity sha1-ilA2CAiMh7HCL5A0rgMuGJiVWGc=
+
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"


### PR DESCRIPTION
## Description

 + [x] add `toPng` using `dom-to-image`: Screenshot Chart + Enable processing of `dataUrl`,
 + [x] Add default download handler, and
 + [x] Pass `dataUrl` to `handleDownload` and `handleShare` functions if provide.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1779590/64961978-475a2300-d89f-11e9-849d-d99f1af45e9a.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation