### PR TITLE
... And then there were none

### DIFF
--- a/src/core/BarChart/index.js
+++ b/src/core/BarChart/index.js
@@ -111,11 +111,10 @@ function BarChart({
   return (
     <Chart {...chartProps}>
       <VictoryAxis
-        tickFormat={tickFormat}
-        tickLabelComponent={<WrapLabel width={labelWidth} />}
-        {...axisProps.independent}
+        dependentAxis
+        orientation={horizontal ? 'bottom' : 'right'}
+        {...axisProps.dependent}
       />
-      <VictoryAxis dependentAxis orientation="right" {...axisProps.dependent} />
 
       <VictoryGroup {...groupProps} offset={offset}>
         {groupData.map((data, i) => (
@@ -142,6 +141,12 @@ function BarChart({
           />
         ))}
       </VictoryGroup>
+      <VictoryAxis
+        tickFormat={tickFormat}
+        tickLabelComponent={<WrapLabel width={labelWidth} />}
+        {...axisProps.independent}
+      />
+
       {legend && (
         <VictoryLegend
           standalone={false}

--- a/src/core/BulletChart/BulletBar.js
+++ b/src/core/BulletChart/BulletBar.js
@@ -26,6 +26,7 @@ function BulletBar({
     <VictoryTooltip constrainToVisibleArea {...tooltipProps} theme={theme} />
   );
   const activateTooltip = (evt, newTooltipProps) => {
+    console.log('BOOM', newTooltipProps);
     if (newTooltipProps && newTooltipProps.text) {
       const { x: tipX, y: tipY } = Selection.getSVGEventCoordinates(evt);
       setTooltipProps({ active: true, ...newTooltipProps, x: tipX, y: tipY });
@@ -75,7 +76,7 @@ function BulletBar({
         events={{
           onMouseOver: evt =>
             activateTooltip(evt, {
-              text: data[0]
+              text: labels(data[0])
             }),
           onMouseMove: evt =>
             activateTooltip(evt, {

--- a/src/core/BulletChart/BulletBar.js
+++ b/src/core/BulletChart/BulletBar.js
@@ -10,57 +10,51 @@ function BulletBar({
   labels,
   reference,
   style = {},
+  theme,
   total,
   width,
   x,
   y
 }) {
   const featuredMeasure = (width * data[0].x) / total;
-  const [featureMeasureStatus, setFeatureMeasureStatus] = useState({});
-  const featureMeasureTooltip = (
-    <VictoryTooltip
-      pointerLength={0}
-      flyoutStyle={{ fill: '#fff' }}
-      constrainToVisibleArea
-      {...featureMeasureStatus}
-      text={labels(data[0])}
-    />
-  );
-  const [, qualitativeMeasure] = data;
-  const [qualitativeMeasureStatus, setQualitativeMeasureStatus] = useState({});
-  const qualitativeMeasureTooltip = qualitativeMeasure && (
-    <VictoryTooltip
-      pointerLength={0}
-      constrainToVisibleArea
-      {...qualitativeMeasureStatus}
-      text={labels(qualitativeMeasure)}
-    />
-  );
+  const [tooltipProps, setTooltipProps] = useState({});
+  const [, qualitativeMeasureProp] = data;
+  const qualitativeMeasure = qualitativeMeasureProp || { x: total };
   const comparativeMeasure = (width * reference.data[0].x) / total;
-  const activateStatus = (setStatus, evt) => {
-    const { x: tipX, y: tipY } = Selection.getSVGEventCoordinates(evt);
-    setStatus({ active: true, x: tipX, y: tipY });
+
+  const tooltip = (
+    <VictoryTooltip constrainToVisibleArea {...tooltipProps} theme={theme} />
+  );
+  const activateTooltip = (evt, newTooltipProps) => {
+    if (newTooltipProps && newTooltipProps.text) {
+      const { x: tipX, y: tipY } = Selection.getSVGEventCoordinates(evt);
+      setTooltipProps({ active: true, ...newTooltipProps, x: tipX, y: tipY });
+    }
   };
 
   return (
     <>
       {/* Qualitative scale */}
-      {qualitativeMeasure && (
-        <VictoryLabel
-          capHeight={0}
-          lineHeight={0}
-          textAnchor="end"
-          x={x + width}
-          y={y - 2 * barWidth}
-          text={labels(qualitativeMeasure)}
-          style={style.labels}
-        />
-      )}
+      <VictoryLabel
+        capHeight={0}
+        lineHeight={0}
+        textAnchor="end"
+        x={x + width}
+        y={y - 2 * barWidth}
+        text={labels(qualitativeMeasure)}
+        style={style.labels}
+      />
       <Border
         events={{
-          onMouseOver: evt => activateStatus(setQualitativeMeasureStatus, evt),
-          onMouseMove: evt => activateStatus(setQualitativeMeasureStatus, evt),
-          onMouseOut: () => setQualitativeMeasureStatus({ active: false })
+          onMouseOver: evt =>
+            activateTooltip(evt, {
+              text: labels(qualitativeMeasure)
+            }),
+          onMouseMove: evt =>
+            activateTooltip(evt, {
+              text: labels(qualitativeMeasure)
+            }),
+          onMouseOut: () => setTooltipProps({ active: false })
         }}
         x={x}
         y={y - barWidth}
@@ -68,7 +62,6 @@ function BulletBar({
         height={barWidth}
         style={style.labels}
       />
-      {qualitativeMeasureTooltip}
       {/* Feature measure */}
       <VictoryLabel
         capHeight={0}
@@ -80,9 +73,15 @@ function BulletBar({
       />
       <Border
         events={{
-          onMouseOver: evt => activateStatus(setFeatureMeasureStatus, evt),
-          onMouseMove: evt => activateStatus(setFeatureMeasureStatus, evt),
-          onMouseOut: () => setFeatureMeasureStatus({ active: false })
+          onMouseOver: evt =>
+            activateTooltip(evt, {
+              text: data[0]
+            }),
+          onMouseMove: evt =>
+            activateTooltip(evt, {
+              text: labels(data[0])
+            }),
+          onMouseOut: () => setTooltipProps({ active: false })
         }}
         x={x}
         y={y - barWidth}
@@ -90,8 +89,7 @@ function BulletBar({
         height={barWidth}
         style={style.data}
       />
-      {featureMeasureTooltip}
-      {/* Comparative measure */}
+      {/* Comparative measure / Target */}
       <Rect
         x={x + comparativeMeasure}
         y={y - barWidth}
@@ -99,6 +97,7 @@ function BulletBar({
         height={barWidth}
         style={reference.style && reference.style.data}
       />
+      {tooltip}
     </>
   );
 }
@@ -112,6 +111,7 @@ BulletBar.propTypes = {
     data: PropTypes.shape({}),
     labels: PropTypes.shape({})
   }),
+  theme: propTypes.theme,
   total: PropTypes.number.isRequired,
   width: PropTypes.number,
   x: PropTypes.number,
@@ -122,6 +122,7 @@ BulletBar.defaultProps = {
   barWidth: undefined,
   reference: undefined,
   style: undefined,
+  theme: undefined,
   width: undefined,
   x: undefined,
   y: undefined

--- a/src/core/BulletChart/BulletBar.js
+++ b/src/core/BulletChart/BulletBar.js
@@ -26,7 +26,6 @@ function BulletBar({
     <VictoryTooltip constrainToVisibleArea {...tooltipProps} theme={theme} />
   );
   const activateTooltip = (evt, newTooltipProps) => {
-    console.log('BOOM', newTooltipProps);
     if (newTooltipProps && newTooltipProps.text) {
       const { x: tipX, y: tipY } = Selection.getSVGEventCoordinates(evt);
       setTooltipProps({ active: true, ...newTooltipProps, x: tipX, y: tipY });

--- a/src/core/BulletChart/BulletBar.js
+++ b/src/core/BulletChart/BulletBar.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { Rect, VictoryLabel } from 'victory';
+import { Border, Rect, Selection, VictoryLabel, VictoryTooltip } from 'victory';
 import propTypes from '../propTypes';
 
 function BulletBar({
@@ -16,8 +16,31 @@ function BulletBar({
   y
 }) {
   const featuredMeasure = (width * data[0].x) / total;
+  const [featureMeasureStatus, setFeatureMeasureStatus] = useState({});
+  const featureMeasureTooltip = (
+    <VictoryTooltip
+      pointerLength={0}
+      flyoutStyle={{ fill: '#fff' }}
+      constrainToVisibleArea
+      {...featureMeasureStatus}
+      text={labels(data[0])}
+    />
+  );
   const [, qualitativeMeasure] = data;
+  const [qualitativeMeasureStatus, setQualitativeMeasureStatus] = useState({});
+  const qualitativeMeasureTooltip = qualitativeMeasure && (
+    <VictoryTooltip
+      pointerLength={0}
+      constrainToVisibleArea
+      {...qualitativeMeasureStatus}
+      text={labels(qualitativeMeasure)}
+    />
+  );
   const comparativeMeasure = (width * reference.data[0].x) / total;
+  const activateStatus = (setStatus, evt) => {
+    const { x: tipX, y: tipY } = Selection.getSVGEventCoordinates(evt);
+    setStatus({ active: true, x: tipX, y: tipY });
+  };
 
   return (
     <>
@@ -33,13 +56,19 @@ function BulletBar({
           style={style.labels}
         />
       )}
-      <Rect
+      <Border
+        events={{
+          onMouseOver: evt => activateStatus(setQualitativeMeasureStatus, evt),
+          onMouseMove: evt => activateStatus(setQualitativeMeasureStatus, evt),
+          onMouseOut: () => setQualitativeMeasureStatus({ active: false })
+        }}
         x={x}
         y={y - barWidth}
         width={width}
         height={barWidth}
         style={style.labels}
       />
+      {qualitativeMeasureTooltip}
       {/* Feature measure */}
       <VictoryLabel
         capHeight={0}
@@ -49,13 +78,19 @@ function BulletBar({
         text={labels(data[0])}
         style={style.data}
       />
-      <Rect
+      <Border
+        events={{
+          onMouseOver: evt => activateStatus(setFeatureMeasureStatus, evt),
+          onMouseMove: evt => activateStatus(setFeatureMeasureStatus, evt),
+          onMouseOut: () => setFeatureMeasureStatus({ active: false })
+        }}
         x={x}
         y={y - barWidth}
         width={featuredMeasure}
         height={barWidth}
         style={style.data}
       />
+      {featureMeasureTooltip}
       {/* Comparative measure */}
       <Rect
         x={x + comparativeMeasure}

--- a/src/core/BulletChart/index.js
+++ b/src/core/BulletChart/index.js
@@ -59,7 +59,7 @@ function BulletChart({
   };
 
   return (
-    <CustomContainer width={width} height={height}>
+    <CustomContainer height={height} theme={theme} width={width}>
       {/* We're plotting from bottom up so start with last item */}
       {computedData.reverse().map((d, i) => (
         <g key={JSON.stringify(d)}>
@@ -70,8 +70,14 @@ function BulletChart({
             reference={reference}
             style={{
               ...computedStyle,
-              data: { fill: chart.colorScale[i % chart.colorScale.length] }
+              data: {
+                fill:
+                  chart.colorScale[
+                    (computedData.length - i - 1) % chart.colorScale.length
+                  ]
+              }
             }}
+            theme={theme}
             total={total}
             width={
               isDirectionColumn

--- a/src/core/ComparisonBarChart.js
+++ b/src/core/ComparisonBarChart.js
@@ -4,17 +4,18 @@ import PropTypes from 'prop-types';
 import { Border, VictoryLabel } from 'victory';
 
 import propTypes from './propTypes';
-import CustomContainer from './CustomContainer';
-import withVictoryTheme from './styles/withVictoryTheme';
 import { toReferenceProps } from './ReferableChart';
+import withVictoryTheme from './styles/withVictoryTheme';
+import CustomContainer from './CustomContainer';
 
 function ComparisonBarChart({
-  theme,
+  barHeight: barHeightProp,
   data,
   height: heightProp,
   horizontal = true,
   reference: referenceProp,
   style = {},
+  theme,
   width: widthProp
 }) {
   const { comparisonBar: chart } = theme;
@@ -34,7 +35,8 @@ function ComparisonBarChart({
   const values = data.map(d => d.y).concat(referenceData.y);
   const max = Math.max.apply(null, values);
   const dataBarWidths = data.map(d => (d.y * width) / max);
-  const referenceDataWidth = (referenceData.y * width) / max;
+  const referenceDataBarWidth = (referenceData.y * width) / max;
+  const barHeight = barHeightProp || chart.barHeight;
 
   return (
     <CustomContainer
@@ -47,43 +49,53 @@ function ComparisonBarChart({
         <>
           <VictoryLabel
             capHeight={0}
-            lineHeight={0}
-            x={0}
-            y={(i + 1) * 40 - 5 + i * 10}
             dy={0}
-            text={data[i].y}
+            lineHeight={0}
             style={{ fill: colorScale[i % colorScale.length], ...dataStyle }}
+            text={data[i].y}
+            x={0}
+            y={(i + 1) * 40 + i * 10 - barHeight}
           />
           <Border
-            x={0}
-            y={(i + 1) * 40 + i * 10}
-            width={barWidth}
-            height={5}
+            height={barHeight}
             style={{ fill: colorScale[i % colorScale.length] }}
+            x={0}
+            width={barWidth}
+            y={(i + 1) * 40 + i * 10}
           />
         </>
       ))}
       <VictoryLabel
         capHeight={0}
+        dy={0}
         lineHeight={0}
-        x={0}
-        y={data.length * 40 + 80}
-        dy={10}
-        text={referenceData.y}
         style={referenceStyle.data}
+        text={referenceData.y}
+        x={0}
+        y={data.length * 40 + (data.length - 1) * 10 - 2 * barHeight + 70}
       />
       <Border
-        x={0}
-        y={data.length * 40 + 120}
-        width={referenceDataWidth}
-        height={5}
+        height={barHeight}
         style={referenceStyle.labels}
+        width={referenceDataBarWidth}
+        x={0}
+        y={data.length * 40 + (data.length - 1) * 10 - barHeight + 70}
+      />
+      <VictoryLabel
+        capHeight={0}
+        dy={0}
+        lineHeight={0}
+        style={referenceStyle.labels}
+        text={referenceData.x}
+        x={0}
+        y={data.length * 40 + (data.length - 1) * 10 + 3 * barHeight + 70}
       />
     </CustomContainer>
   );
 }
 
 ComparisonBarChart.propTypes = {
+  barHeight: PropTypes.number,
   data: PropTypes.arrayOf(
     PropTypes.shape({ x: PropTypes.string, y: PropTypes.number })
   ).isRequired,
@@ -99,6 +111,7 @@ ComparisonBarChart.propTypes = {
 };
 
 ComparisonBarChart.defaultProps = {
+  barHeight: undefined,
   height: undefined,
   horizontal: undefined,
   reference: undefined,

--- a/src/core/ComparisonBarChart.js
+++ b/src/core/ComparisonBarChart.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { Border, VictoryLabel } from 'victory';
+import { Border, Selection, VictoryLabel, VictoryTooltip } from 'victory';
 
 import propTypes from './propTypes';
 import { toReferenceProps } from './ReferableChart';
@@ -18,6 +18,7 @@ function ComparisonBarChart({
   theme,
   width: widthProp
 }) {
+  const [tooltipProps, setTooltipProps] = useState({});
   const { comparisonBar: chart } = theme;
   if (!data || !chart) {
     return null;
@@ -38,6 +39,16 @@ function ComparisonBarChart({
   const referenceDataBarWidth = (referenceData.y * width) / max;
   const barHeight = barHeightProp || chart.barHeight;
 
+  const tooltip = (
+    <VictoryTooltip constrainToVisibleArea {...tooltipProps} theme={theme} />
+  );
+  const activateTooltip = (evt, newTooltipProps) => {
+    if (newTooltipProps && newTooltipProps.text) {
+      const { x: tipX, y: tipY } = Selection.getSVGEventCoordinates(evt);
+      setTooltipProps({ active: true, ...newTooltipProps, x: tipX, y: tipY });
+    }
+  };
+
   return (
     <CustomContainer
       theme={theme}
@@ -57,6 +68,13 @@ function ComparisonBarChart({
             y={(i + 1) * 40 + i * 10 - barHeight}
           />
           <Border
+            events={{
+              onMouseOver: evt =>
+                activateTooltip(evt, { text: `${data[i].x}: ${data[i].y}` }),
+              onMouseMove: evt =>
+                activateTooltip(evt, { text: `${data[i].x}: ${data[i].y}` }),
+              onMouseOut: () => setTooltipProps({ active: false })
+            }}
             height={barHeight}
             style={{ fill: colorScale[i % colorScale.length] }}
             x={0}
@@ -75,6 +93,17 @@ function ComparisonBarChart({
         y={data.length * 40 + (data.length - 1) * 10 - 2 * barHeight + 70}
       />
       <Border
+        events={{
+          onMouseOver: evt =>
+            activateTooltip(evt, {
+              text: `${referenceData.x}: ${referenceData.y}`
+            }),
+          onMouseMove: evt =>
+            activateTooltip(evt, {
+              text: `${referenceData.x}: ${referenceData.y}`
+            }),
+          onMouseOut: () => setTooltipProps({ active: false })
+        }}
         height={barHeight}
         style={referenceStyle.labels}
         width={referenceDataBarWidth}
@@ -90,6 +119,7 @@ function ComparisonBarChart({
         x={0}
         y={data.length * 40 + (data.length - 1) * 10 + 3 * barHeight + 70}
       />
+      {tooltip}
     </CustomContainer>
   );
 }

--- a/src/core/ComparisonBarChart.js
+++ b/src/core/ComparisonBarChart.js
@@ -57,7 +57,7 @@ function ComparisonBarChart({
       height={height}
     >
       {dataBarWidths.map((barWidth, i) => (
-        <>
+        <React.Fragment key={data[i].x}>
           <VictoryLabel
             capHeight={0}
             dy={0}
@@ -81,7 +81,7 @@ function ComparisonBarChart({
             width={barWidth}
             y={(i + 1) * 40 + i * 10}
           />
-        </>
+        </React.Fragment>
       ))}
       <VictoryLabel
         capHeight={0}

--- a/src/core/LineChart.js
+++ b/src/core/LineChart.js
@@ -35,6 +35,7 @@ import propTypes from './propTypes';
 function LineChart({
   data,
   height: suggestedHeight,
+  horizontal,
   padding: suggestedPadding,
   parts,
   style,
@@ -74,6 +75,7 @@ function LineChart({
 
   const chartProps = {
     height,
+    horizontal,
     padding,
     width,
     ...(parts && parts.parent)
@@ -92,7 +94,11 @@ function LineChart({
       {...chartProps}
     >
       <VictoryAxis {...axisProps.independent} />
-      <VictoryAxis dependentAxis orientation="right" {...axisProps.dependent} />
+      <VictoryAxis
+        dependentAxis
+        orientation={horizontal ? 'bottom' : 'right'}
+        {...axisProps.dependent}
+      />
 
       {groupData.map((gd, i) => (
         <VictoryLine
@@ -129,6 +135,7 @@ function LineChart({
 LineChart.propTypes = {
   data: propTypes.groupedData,
   height: PropTypes.number,
+  horizontal: PropTypes.bool,
   padding: PropTypes.oneOfType([PropTypes.number, PropTypes.shape({})]),
   parts: PropTypes.shape({
     axis: PropTypes.shape({}),
@@ -150,6 +157,7 @@ LineChart.propTypes = {
 LineChart.defaultProps = {
   data: undefined,
   height: undefined,
+  horizontal: undefined,
   padding: undefined,
   parts: undefined,
   style: undefined,

--- a/src/core/NestedProportionalAreaChart/HorizontalLegend.js
+++ b/src/core/NestedProportionalAreaChart/HorizontalLegend.js
@@ -58,7 +58,7 @@ function HorizontalLegend({
             dx={0}
             y={cy}
             dy={18} // 36 / 2 since we want data value vertical centered
-            text={formatNumberForLabel(data[i].x)}
+            text={formatNumberForLabel(data[i].y)}
             style={dataLabelsStyle(i, colorScale, style)}
           />
           {data[i].label && (
@@ -83,7 +83,7 @@ function HorizontalLegend({
         lineHeight={0}
         x={cx + 200}
         y={2 * cy - 24}
-        text={formatNumberForLabel(referenceData.x)}
+        text={formatNumberForLabel(referenceData.y)}
         style={referenceDataStyle(reference)}
       />
       {referenceData.label && (

--- a/src/core/NestedProportionalAreaChart/ScaledCircle.js
+++ b/src/core/NestedProportionalAreaChart/ScaledCircle.js
@@ -24,6 +24,7 @@ function ScaledCircle({
   mobile,
   reference,
   style,
+  theme,
   ...props
 }) {
   const cx = mobile ? MOBILE_WIDTH / 2 : DESKTOP_WIDTH / 2;
@@ -47,51 +48,55 @@ function ScaledCircle({
   return (
     <>
       <PieChart
+        {...props}
         data={backgroundData}
         donut={false}
         height={height}
         origin={{ x: cx, y: cy }}
         radius={size}
         standalone={false}
-        width={width}
-        {...props}
         style={referenceStyle}
-      />
-      <PieChart
-        colorScale={colorScale}
-        height={height}
-        data={radii.map(v => [v])}
-        origin={{ x: cx, y: cy }}
-        radii={radii}
-        standalone={false}
+        theme={theme}
         width={width}
-        {...props}
-        donut={false}
-        labelComponent={<Tooltip />}
-        labels={data.map(
-          d => `${d.y}: ${d.x}\n${referenceData.y}: ${referenceData.x}`
-        )}
       />
       {mobile ? (
         <VerticalLegend
-          data={data}
           colorScale={colorScale}
+          data={data}
+          formatNumberForLabel={formatNumberForLabel}
           reference={reference}
           style={style}
-          formatNumberForLabel={formatNumberForLabel}
+          theme={theme}
         />
       ) : (
         <HorizontalLegend
-          data={data}
-          radii={radii}
           colorScale={colorScale}
-          style={style}
-          reference={reference}
           cx={cx}
           cy={cy}
+          data={data}
           formatNumberForLabel={formatNumberForLabel}
+          radii={radii}
+          reference={reference}
+          style={style}
+          theme={theme}
         />
       )}
+      <PieChart
+        {...props}
+        colorScale={colorScale}
+        data={radii.map(v => [v])}
+        donut={false}
+        height={height}
+        labels={data.map(
+          d => `${d.y}: ${d.x}\n${referenceData.y}: ${referenceData.x}`
+        )}
+        labelComponent={<Tooltip theme={theme} />}
+        origin={{ x: cx, y: cy }}
+        radii={radii}
+        standalone={false}
+        theme={theme}
+        width={width}
+      />
     </>
   );
 }
@@ -105,7 +110,8 @@ ScaledCircle.propTypes = {
   reference: propTypes.reference,
   style: PropTypes.shape({
     labels: PropTypes.shape({})
-  })
+  }),
+  theme: propTypes.theme
 };
 
 ScaledCircle.defaultProps = {
@@ -114,7 +120,8 @@ ScaledCircle.defaultProps = {
   data: undefined,
   mobile: false,
   reference: undefined,
-  style: undefined
+  style: undefined,
+  theme: undefined
 };
 
 export default ScaledCircle;

--- a/src/core/NestedProportionalAreaChart/ScaledCircle.js
+++ b/src/core/NestedProportionalAreaChart/ScaledCircle.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import propTypes from '../propTypes';
 import {
   DESKTOP_HEIGHT,
   DESKTOP_WIDTH,
@@ -9,8 +10,8 @@ import {
 } from './ScaledArea';
 import HorizontalLegend from './HorizontalLegend';
 import PieChart from '../PieChart';
+import Tooltip from '../Tooltip';
 import VerticalLegend from './VerticalLegend';
-import propTypes from '../propTypes';
 
 /**
  *
@@ -60,12 +61,16 @@ function ScaledCircle({
         colorScale={colorScale}
         height={height}
         data={radii.map(v => [v])}
-        donut={false}
         origin={{ x: cx, y: cy }}
         radii={radii}
         standalone={false}
         width={width}
         {...props}
+        donut={false}
+        labelComponent={<Tooltip />}
+        labels={data.map(
+          d => `${d.y}: ${d.x}\n${referenceData.y}: ${referenceData.x}`
+        )}
       />
       {mobile ? (
         <VerticalLegend

--- a/src/core/NestedProportionalAreaChart/ScaledCircle.js
+++ b/src/core/NestedProportionalAreaChart/ScaledCircle.js
@@ -37,8 +37,8 @@ function ScaledCircle({
     style: referenceStyle
   } = reference;
   const radii = data.map(d =>
-    d.x !== referenceData.x
-      ? (Math.sqrt(d.x) * size) / Math.sqrt(referenceData.x)
+    d.y !== referenceData.y
+      ? (Math.sqrt(d.y) * size) / Math.sqrt(referenceData.y)
       : size
   );
 
@@ -88,7 +88,7 @@ function ScaledCircle({
         donut={false}
         height={height}
         labels={data.map(
-          d => `${d.y}: ${d.x}\n${referenceData.y}: ${referenceData.x}`
+          d => `${d.x}: ${d.y}\n${referenceData.x}: ${referenceData.y}`
         )}
         labelComponent={<Tooltip theme={theme} />}
         origin={{ x: cx, y: cy }}

--- a/src/core/NestedProportionalAreaChart/ScaledSquare.js
+++ b/src/core/NestedProportionalAreaChart/ScaledSquare.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { Rect } from 'victory';
+import { Border, Selection, VictoryTooltip } from 'victory';
 
 import { MOBILE_WIDTH } from './ScaledArea';
 import VerticalLegend from './VerticalLegend';
@@ -24,12 +24,19 @@ function ScaledSquare({
     data: [referenceData],
     style: referenceStyle
   } = reference;
+  const [status, setStatus] = useState({});
+  const statusTooltip = <VictoryTooltip constrainToVisibleArea {...status} />;
+
+  const activateTooltip = (evt, text) => {
+    const { x: tipX, y: tipY } = Selection.getSVGEventCoordinates(evt);
+    setStatus({ active: true, text, x: tipX, y: tipY });
+  };
 
   // NOTE: Nested square must be sorted to ensure they're all visible
   // but we need to remember original position to ensure right color is used.
   return (
     <>
-      <Rect
+      <Border
         {...props}
         key={referenceData.x}
         height={size}
@@ -46,9 +53,17 @@ function ScaledSquare({
             d.value.x !== referenceData.x
               ? (Math.sqrt(d.value.x) * size) / Math.sqrt(referenceData.x)
               : size;
+
           return (
-            <Rect
+            <Border
               {...props}
+              events={{
+                onMouseOver: evt =>
+                  activateTooltip(evt, `${d.value.y}: ${d.value.x}`),
+                onMouseMove: evt =>
+                  activateTooltip(evt, `${d.value.y}: ${d.value.x}`),
+                onMouseOut: () => setStatus({ active: false })
+              }}
               key={scaledSide}
               height={scaledSide}
               style={{ fill: colorScale[d.index % colorScale.length] }}
@@ -65,6 +80,7 @@ function ScaledSquare({
         style={style}
         formatNumberForLabel={formatNumberForLabel}
       />
+      {statusTooltip}
     </>
   );
 }

--- a/src/core/NestedProportionalAreaChart/ScaledSquare.js
+++ b/src/core/NestedProportionalAreaChart/ScaledSquare.js
@@ -27,12 +27,12 @@ function ScaledSquare({
     style: referenceStyle
   } = reference;
   const referenceText =
-    referenceData && `${referenceData.y}: ${referenceData.x}`;
+    referenceData && `${referenceData.x}: ${referenceData.y}`;
   const [tooltipProps, setTooltipProps] = useState({});
   const tooltip = <VictoryTooltip theme={theme} {...tooltipProps} />;
   const activateTooltip = (evt, { data: dataProp, ...otherProps }) => {
     if (dataProp) {
-      const dataText = `${dataProp.y}: ${dataProp.x}`;
+      const dataText = `${dataProp.x}: ${dataProp.y}`;
       const text = referenceText ? `${dataText}\n${referenceText}` : dataText;
       const { x: tipX, y: tipY } = Selection.getSVGEventCoordinates(evt);
       setTooltipProps({ active: true, ...otherProps, text, x: tipX, y: tipY });
@@ -54,11 +54,11 @@ function ScaledSquare({
       />
       {data
         .map((v, i) => ({ value: v, index: i }))
-        .sort((a, b) => b.value.x - a.value.x)
+        .sort((a, b) => b.value.y - a.value.y)
         .map(d => {
           const scaledSide =
-            d.value.x !== referenceData.x
-              ? (Math.sqrt(d.value.x) * size) / Math.sqrt(referenceData.x)
+            d.value.y !== referenceData.y
+              ? (Math.sqrt(d.value.y) * size) / Math.sqrt(referenceData.y)
               : size;
 
           return (
@@ -101,16 +101,8 @@ ScaledSquare.propTypes = {
       })
     )
   ]),
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      x: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-      label: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-    })
-  ),
-  reference: PropTypes.shape({
-    data: PropTypes.arrayOf(PropTypes.shape({})),
-    style: PropTypes.arrayOf(PropTypes.shape({}))
-  }),
+  data: propTypes.data,
+  reference: propTypes.reference,
   style: PropTypes.shape({
     labels: PropTypes.shape({})
   }),

--- a/src/core/NestedProportionalAreaChart/ScaledSquare.js
+++ b/src/core/NestedProportionalAreaChart/ScaledSquare.js
@@ -93,14 +93,7 @@ function ScaledSquare({
 
 ScaledSquare.propTypes = {
   formatNumberForLabel: PropTypes.func,
-  colorScale: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(
-      PropTypes.shape({
-        x: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-      })
-    )
-  ]),
+  colorScale: propTypes.colorScale,
   data: propTypes.data,
   reference: propTypes.reference,
   style: PropTypes.shape({

--- a/src/core/NestedProportionalAreaChart/VerticalLegend.js
+++ b/src/core/NestedProportionalAreaChart/VerticalLegend.js
@@ -43,7 +43,7 @@ function VerticalLegend({
           x={x}
           dx={0}
           y={90} // 100 - 10
-          text={formatNumberForLabel(d.x)}
+          text={formatNumberForLabel(d.y)}
           style={dataLabelsStyle(i, colorScale, style)}
           dy={-i * 36}
         />
@@ -55,7 +55,7 @@ function VerticalLegend({
         lineHeight={0}
         x={x}
         y={MOBILE_HEIGHT - 25}
-        text={formatNumberForLabel(referenceData.x)}
+        text={formatNumberForLabel(referenceData.y)}
         style={referenceDataStyle(reference)}
       />
       {referenceData.label && (

--- a/src/core/NestedProportionalAreaChart/index.js
+++ b/src/core/NestedProportionalAreaChart/index.js
@@ -76,9 +76,10 @@ function NestedProportionalAreaChart({
           {square ? (
             <ScaledSquare
               colorScale={chart.colorScale}
-              reference={reference}
               data={data}
               formatNumberForLabel={formatNumberForLabel}
+              reference={reference}
+              theme={theme}
             />
           ) : (
             <ScaledCircle

--- a/src/core/NestedProportionalAreaChart/index.js
+++ b/src/core/NestedProportionalAreaChart/index.js
@@ -103,7 +103,7 @@ function NestedProportionalAreaChart({
 
 NestedProportionalAreaChart.propTypes = {
   formatNumberForLabel: PropTypes.func,
-  data: propTypes.groupedData,
+  data: propTypes.data,
   groupSpacing: PropTypes.number,
   height: PropTypes.number,
   reference: propTypes.reference,

--- a/src/core/NestedProportionalAreaChart/index.js
+++ b/src/core/NestedProportionalAreaChart/index.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import propTypes from '../propTypes';
 import { scaleDesktopDimensions, scaleMobileDimensions } from './ScaledArea';
 import { toReferenceProps } from '../ReferableChart';
 import withVictoryTheme from '../styles/withVictoryTheme';
 import CustomContainer from '../CustomContainer';
 import ScaledCircle from './ScaledCircle';
 import ScaledSquare from './ScaledSquare';
-import propTypes from '../propTypes';
 
 /**
  * Data value represents **area**. We need to find length/radius in order to

--- a/src/core/PieChart/SharedEvents.js
+++ b/src/core/PieChart/SharedEvents.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { darken } from '@material-ui/core/styles/colorManipulator';
 
-import { VictorySharedEvents } from 'victory';
+import { Selection, VictorySharedEvents } from 'victory';
 
 const activateData = (childName, emphasisCoefficient) => {
   return {
@@ -21,11 +21,13 @@ const activateData = (childName, emphasisCoefficient) => {
 
 // By not specifying the childName, the event will only affect the component
 // that triggered the event: https://formidable.com/open-source/victory/guides/events#single-component-events
-const activateLabels = (donut, childName) => {
+const activateLabels = (evt, donut, childName) => {
+  const { x, y } = !donut ? Selection.getSVGEventCoordinates(evt) : {};
+
   return {
     childName: donut ? childName : undefined,
     target: 'labels',
-    mutation: () => ({ active: true })
+    mutation: () => ({ x, y, active: true })
   };
 };
 
@@ -44,10 +46,16 @@ function SharedEvents({ childName, children, donut, emphasisCoefficient }) {
         {
           childName,
           eventHandlers: {
-            onMouseOver: () => {
+            onMouseOver: evt => {
               return [
                 activateData(childName, emphasisCoefficient),
-                activateLabels(donut, childName)
+                activateLabels(evt, donut, childName)
+              ];
+            },
+            onMouseMove: evt => {
+              return [
+                // activateData(childName, emphasisCoefficient),
+                activateLabels(evt, donut, childName)
               ];
             },
             onMouseOut: () => {

--- a/src/core/PieChart/index.js
+++ b/src/core/PieChart/index.js
@@ -163,8 +163,9 @@ function PieChart({
     />
   ) : (
     <Tooltip
-      constrainToVisibleArea
+      // constrainToVisibleArea
       {...tooltipProps}
+      flyoutStyle={{ fill: 'white', stroke: 'none' }}
       labelComponent={<Label colorScale={colorScale} />}
       orientation={data2 && data2.length > 0 ? 'left' : undefined}
       renderInPortal={false}
@@ -174,7 +175,9 @@ function PieChart({
   if (data2 && data2.length > 0 && !donut) {
     labelComponent2 = (
       <Tooltip
+        // constrainToVisibleArea
         {...tooltipProps}
+        flyoutStyle={{ fill: 'white', stroke: 'none' }}
         labelComponent={<Label colorScale={colorScale} />}
         orientation="right"
         renderInPortal={false}

--- a/src/core/PieChart/index.js
+++ b/src/core/PieChart/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Helpers, VictoryPie, VictoryLegend, VictoryTooltip } from 'victory';
+import { Helpers, VictoryPie, VictoryLegend } from 'victory';
 
 import { getLegendProps } from '../utils';
 import propTypes from '../propTypes';
@@ -22,7 +22,7 @@ const computeRadii = (width, height, padding, groupSpacing = 0) => {
 function PieChart({
   colorScale: colorScaleProp,
   data,
-  donut,
+  donut: donutProp,
   donutLabelKey,
   groupSpacing,
   height: heightProp,
@@ -105,8 +105,9 @@ function PieChart({
           computedGroupSpacing
         ));
   const chartRadius = Math.max.apply(null, computedRadii);
+  const donut = donutProp || (typeof donutProp === 'undefined' && chart.donut);
   let chartInnerRadius = 0;
-  if (donut || (typeof donut === 'undefined' && chart.donut)) {
+  if (donut) {
     chartInnerRadius =
       innerRadiusProp && innerRadiusProp > 0
         ? innerRadiusProp
@@ -133,9 +134,9 @@ function PieChart({
   };
   const tooltipStyle = {
     ...donutLabelStyle,
-    ...(tooltipProps.style && tooltipProps.style.labels)
+    ...tooltipProps.style
   };
-  const Tooltip = isComparisonMode ? VictoryTooltip : SharedEventTooltip;
+  const Tooltip = SharedEventTooltip;
   // We define tooltip for donut label component here than using a separate
   // due to svg rendering components in the provided order and we don't have
   // z-index property to reorder them.
@@ -163,21 +164,19 @@ function PieChart({
     />
   ) : (
     <Tooltip
-      // constrainToVisibleArea
+      constrainToVisibleArea
       {...tooltipProps}
-      flyoutStyle={{ fill: 'white', stroke: 'none' }}
       labelComponent={<Label colorScale={colorScale} />}
-      orientation={data2 && data2.length > 0 ? 'left' : undefined}
+      orientation={isComparisonMode ? 'left' : undefined}
       renderInPortal={false}
     />
   );
   let labelComponent2 = labelComponent1;
-  if (data2 && data2.length > 0 && !donut) {
+  if (isComparisonMode && !donut) {
     labelComponent2 = (
       <Tooltip
-        // constrainToVisibleArea
+        constrainToVisibleArea
         {...tooltipProps}
-        flyoutStyle={{ fill: 'white', stroke: 'none' }}
         labelComponent={<Label colorScale={colorScale} />}
         orientation="right"
         renderInPortal={false}
@@ -246,7 +245,7 @@ function PieChart({
             width={chartWidth}
             {...props}
           />
-          {data2 && data2.length > 0 && (
+          {isComparisonMode && (
             <VictoryPie
               colorScale={colorScale2}
               data={data2}

--- a/src/core/styles/createVictoryTheme.js
+++ b/src/core/styles/createVictoryTheme.js
@@ -110,8 +110,14 @@ export default function createVictoryTheme(chartOptions) {
   };
   // Customize chart comparisonBar props off of chart group props
   chart.comparisonBar = {
-    reference: defaultReference,
+    referenceStyle: { ...defaultReference, data: { fill: '#9b9b9b' } },
     ...chart.group,
+    style: {
+      data: {
+        fontSize: '24px',
+        fontWeight: 'bold'
+      }
+    },
     ...chart.comparisonBar
   };
   // Customize chart line props off of chart group props

--- a/src/core/styles/createVictoryTheme.js
+++ b/src/core/styles/createVictoryTheme.js
@@ -110,7 +110,11 @@ export default function createVictoryTheme(chartOptions) {
   };
   // Customize chart comparisonBar props off of chart group props
   chart.comparisonBar = {
-    referenceStyle: { ...defaultReference, data: { fill: '#9b9b9b' } },
+    barHeight: 5,
+    referenceStyle: {
+      labels: { fill: '#9b9b9b' },
+      data: { fill: '#9b9b9b', fontWeight: 'bold' }
+    },
     ...chart.group,
     style: {
       data: {

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -396,14 +396,14 @@ storiesOf('HURUmap UI|Charts/ComparisonBarChart', module)
           data={object('data', [
             {
               x: 'Ilala',
-              y: 17
+              y: 22
             },
             {
               x: 'Kinondoni',
               y: 17
             }
           ])}
-          reference={object('reference', [{ x: 'Dar es Salaam', y: 16 }])}
+          reference={object('reference', [{ x: 'Dar es Salaam', y: 28 }])}
         />
       </div>
     );

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -360,8 +360,10 @@ storiesOf('HURUmap UI|Charts/NestedProportionalAreaChart', module)
         square={boolean('square', false)}
         height={number('height', 350)}
         width={number('width', 350)}
-        data={object('data', [{ x: 39626, label: 'People' }])}
-        reference={object('reference', [{ x: 947303, label: 'Tanzania' }])}
+        data={object('data', [{ x: 39626, y: 'City', label: 'People' }])}
+        reference={object('reference', [
+          { x: 947303, y: 'Country', label: 'Country' }
+        ])}
       />
     </div>
   ))
@@ -373,10 +375,12 @@ storiesOf('HURUmap UI|Charts/NestedProportionalAreaChart', module)
         height={number('height', 350)}
         width={number('width', 650)}
         data={object('data', [
-          { x: 76151, label: 'People' },
-          { x: 39626, label: 'People' }
+          { x: 76151, y: 'City 1', label: 'People' },
+          { x: 39626, y: 'City 2', label: 'People' }
         ])}
-        reference={object('reference', [{ x: 947303, label: 'Tanzania' }])}
+        reference={object('reference', [
+          { x: 947303, y: 'Country', label: 'Country' }
+        ])}
         groupSpacing={number('groupSpacing', 8)}
       />
     </div>

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -39,7 +39,7 @@ storiesOf('HURUmap UI|Charts/BarChart', module)
             const y = rand();
             const x = `${index}-${index} Employment Status`;
             return {
-              tooltip: `${x}: Tooltip`,
+              tooltip: `${x}: ${y}`,
               x,
               y
             };
@@ -125,34 +125,60 @@ storiesOf('HURUmap UI|Charts/Bullet Chart', module)
   .add('Default', () => (
     <div>
       <BulletChart
-        width={number('width', 350)}
-        height={number('height', 100)}
         data={object('data', [
           { x: 49, label: 'Male' },
           { x: 51, label: 'Female' }
         ])}
-        total={100}
-        labels={d => `${d.x}% ${d.label}`}
+        height={number('height', 100)}
+        labels={d => (d.label && `${d.label}: ${d.x}%`) || ''}
         reference={object('reference', [{ x: 51, label: '' }])}
+        total={100}
+        width={number('width', 350)}
       />
     </div>
   ))
   .add('Comparison', () => (
     <div>
       <BulletChart
-        width={number('width', 350)}
         height={number('height', 100)}
-        offset={object('offset', { x: 25, y: 50 })}
         data={object('data', [
+          // When no qualitative measure is given, total would be assumed.
+          // Below data is equivalent to:
+          // [{ x: 12.7, label: 'Living in urban areas' }, { x: 100 }],
+          // [{ x: 9.3, label: 'Living in rural areas' }, { x: 100 }]
           [{ x: 12.7, label: 'Living in urban areas' }],
-          [{ x: 9.3, label: 'Living in urban areas' }]
+          [{ x: 9.3, label: 'Living in rural areas' }]
         ])}
+        reference={object('reference', [{ x: 51, label: '' }])}
+        labels={d => (d.label && `${d.label}: ${d.x}%`) || ''}
         total={100}
-        labels={d => `${d.x}% ${d.label}`}
-        reference={object('reference', [{ x: 51 }])}
+        width={number('width', 350)}
       />
     </div>
   ));
+
+storiesOf('HURUmap UI|Charts/ComparisonBarChart', module)
+  .addDecorator(CenterDecorator)
+  .addDecorator(withKnobs)
+  .add('Default', () => {
+    return (
+      <div>
+        <ComparisonBarChart
+          data={object('data', [
+            {
+              x: 'Ilala',
+              y: 22
+            },
+            {
+              x: 'Kinondoni',
+              y: 17
+            }
+          ])}
+          reference={object('reference', [{ x: 'Dar es Salaam', y: 28 }])}
+        />
+      </div>
+    );
+  });
 
 storiesOf('HURUmap UI|Charts/LineChart', module)
   .addDecorator(CenterDecorator)
@@ -256,9 +282,6 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
           width={width}
           height={height}
           parts={{
-            tooltip: {
-              style: object('Tooltip style', undefined)
-            },
             legend: {
               data: [
                 {
@@ -319,12 +342,24 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
               ),
               data: object('Legend data', [
                 {
-                  name: 'Name for data A',
-                  label: 'Description/summary for data A'
+                  name: 'A',
+                  label: 'Dar es Salaam: 1\nKagera: 2'
                 },
                 {
-                  name: 'Name for data B',
-                  label: 'Description/summary for data B'
+                  name: 'B',
+                  label: 'Dar es Salaam: 2\nKagera: 1'
+                },
+                {
+                  name: 'C',
+                  label: 'Dar es Salaam: 3\nKagera: 1'
+                },
+                {
+                  name: 'D',
+                  label: 'Dar es Salaam: 1\nKagera: 1'
+                },
+                {
+                  name: 'E',
+                  label: 'Dar es Salaam: 2\nKagera: 5'
                 }
               ]),
               gutter: number('Legend column spacing', 10),
@@ -385,26 +420,3 @@ storiesOf('HURUmap UI|Charts/NestedProportionalAreaChart', module)
       />
     </div>
   ));
-
-storiesOf('HURUmap UI|Charts/ComparisonBarChart', module)
-  .addDecorator(CenterDecorator)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    return (
-      <div>
-        <ComparisonBarChart
-          data={object('data', [
-            {
-              x: 'Ilala',
-              y: 22
-            },
-            {
-              x: 'Kinondoni',
-              y: 17
-            }
-          ])}
-          reference={object('reference', [{ x: 'Dar es Salaam', y: 28 }])}
-        />
-      </div>
-    );
-  });

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -395,9 +395,9 @@ storiesOf('HURUmap UI|Charts/NestedProportionalAreaChart', module)
         square={boolean('square', false)}
         height={number('height', 350)}
         width={number('width', 350)}
-        data={object('data', [{ x: 39626, y: 'City', label: 'People' }])}
+        data={object('data', [{ x: 'City', y: 39626, label: 'People' }])}
         reference={object('reference', [
-          { x: 947303, y: 'Country', label: 'Country' }
+          { x: 'Country', y: 947303, label: 'Country' }
         ])}
       />
     </div>
@@ -410,11 +410,11 @@ storiesOf('HURUmap UI|Charts/NestedProportionalAreaChart', module)
         height={number('height', 350)}
         width={number('width', 650)}
         data={object('data', [
-          { x: 76151, y: 'City 1', label: 'People' },
-          { x: 39626, y: 'City 2', label: 'People' }
+          { x: 'City 1', y: 76151, label: 'People' },
+          { x: 'City 2', y: 39626, label: 'People' }
         ])}
         reference={object('reference', [
-          { x: 947303, y: 'Country', label: 'Country' }
+          { x: 'Country', y: 947303, label: 'Country' }
         ])}
         groupSpacing={number('groupSpacing', 8)}
       />


### PR DESCRIPTION
## Description

Add tooltips to charts that mainly use [Primitive/Simple](https://formidable.com/open-source/victory/docs/victory-primitives) Victory components.

 - [x] Bullet Chart,
 - [x] Nested Area Chart,
   - [x] Nested Circle,
   - [x] Nested Square,
- [x] Comparison Bar Chart
  - [x] Reimplement using Victory simple components, and
  - [x] Add tooltip support
- [x] Test and fix tooltip support for all charts.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Peek 2019-10-28 14-42](https://user-images.githubusercontent.com/1779590/67676106-e475a480-f991-11e9-8df6-e517eea5ab06.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation