### PR TITLE
Allow population table conditions for fetching

### DIFF
--- a/src/factory/useProfileLoader/queries.js
+++ b/src/factory/useProfileLoader/queries.js
@@ -1,6 +1,9 @@
 // A file that defines needed graphql queries
 import gql from 'graphql-tag';
 
+/**
+ * `populationTables` can the array of strings [...`tableName`] or array [...[`tableName` , {`conditions`}]]
+ */
 export const buildProfileQuery = populationTables => gql`
 query profile($geoCode: String!, $geoLevel: String!) {
   geo: wazimapGeographyByGeoLevelAndGeoCodeAndVersion(
@@ -17,8 +20,20 @@ query profile($geoCode: String!, $geoLevel: String!) {
     name
   }
   ${populationTables.map(
-    (table, i) => `population${i}: ${table}(
-    condition: { geoCode: $geoCode, geoLevel: $geoLevel }
+    (table, i) => `population${i}: ${Array.isArray(table) ? table[0] : table}(
+    ${
+      Array.isArray(table) && table[1]
+        ? JSON.stringify(
+            Object.assign(table[1], {
+              condition: {
+                ...table[1].condition,
+                geoCode: '$geoCode',
+                geoLevel: '$geoLevel'
+              }
+            })
+          ).slice(1, -1)
+        : 'condition: { geoCode: $geoCode, geoLevel: $geoLevel }'
+    }
   ) {
     nodes {
       total


### PR DESCRIPTION
## Description

This feature helps resolve PT issue https://www.pivotaltracker.com/story/show/169501050
When querying for population, allow the table to be queried with conditions example:

```
// Getting latest population
[
      'allTotalPopulation',
      {
        orderBy: 'TOTAL_POPULATION_YEAR_DESC',
        first: 1
      }
]
```
or 

```
// Getting population of year 2017
[
      'allTotalPopulation',
      {
        condition:  { totalPopulationYear: '2017' }
      }
]
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation