### PR TITLE
Hotfix useProfileLoader using wrong parent level and geo code details

### DIFF
--- a/src/factory/useProfileLoader/index.js
+++ b/src/factory/useProfileLoader/index.js
@@ -84,12 +84,8 @@ export default ({ geoId, comparisonGeoId, visuals, populationTables }) => {
           isLoading: true
         });
 
-        const parent = {
-          geoLevel: profiles.parent.parentLevel,
-          geoCode: profiles.parent.parentCode
-        };
         const { data: profileVisualsData } = await client.query({
-          query: buildVisualsQuery(visuals, parent),
+          query: buildVisualsQuery(visuals, profiles.parent),
           variables: {
             geoCode: profiles.profile.geoCode,
             geoLevel: profiles.profile.geoLevel
@@ -99,7 +95,7 @@ export default ({ geoId, comparisonGeoId, visuals, populationTables }) => {
         let comparisonVisualsData;
         if (profiles.comparison) {
           const { data } = await client.query({
-            query: buildVisualsQuery(visuals, parent),
+            query: buildVisualsQuery(visuals, profiles.parent),
             variables: {
               geoCode: profiles.comparison.geoCode,
               geoLevel: profiles.comparison.geoLevel


### PR DESCRIPTION
## Description

We were using the the `parent.parentLevel` and  `parent.parentGeoCode` instead of `parent.geoLevel` and `parent.geoCode`.

Problem discovered here https://github.com/CodeForAfrica/Dominion.AFRICA/pull/51 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation