### PR TITLE
Accept visual definition props

### DIFF
--- a/src/core/BarChart/index.js
+++ b/src/core/BarChart/index.js
@@ -78,14 +78,13 @@ function BarChart({
   const originalPadding = Helpers.getPadding({
     padding:
       suggestedPadding ||
-      (parts.parent && parts.parent.padding) ||
+      (parts && parts.parent && parts.parent.padding) ||
       chart.padding
   });
 
   const initialLegendProps = {
     ...chart.legend,
-    colorScale,
-    ...(parts && parts.legend)
+    colorScale
   };
   const { padding, legend } = getLegendProps(
     { height, width },

--- a/src/core/ChartContainer/index.js
+++ b/src/core/ChartContainer/index.js
@@ -121,6 +121,7 @@ function ChartContainer({
   const dataButtonRef = useRef(null);
 
   const downloadButtonRef = useRef(null);
+  const downloadHiddenClassName = 'Download--hidden';
   const chartRef = useRef(null);
   const toPng = () => {
     const filter = node => {
@@ -131,10 +132,7 @@ function ChartContainer({
           nodeStyle.display = 'flex';
         }
 
-        return !(
-          classList.contains(classes.actions) ||
-          classList.contains(classes.source)
-        );
+        return !classList.contains(downloadHiddenClassName);
       }
       return true;
     };
@@ -281,7 +279,7 @@ function ChartContainer({
             wrap="nowrap"
             direction="row"
             justify="flex-end"
-            className={classes.actions}
+            className={`${downloadHiddenClassName} ${classes.actions}`}
           >
             {onClickShare && (
               <BlockLoader loading={loading} width={40} height={40}>
@@ -382,7 +380,7 @@ function ChartContainer({
                 secondaryOpacity: 1
               }}
               component="div"
-              className={classes.source}
+              className={`${downloadHiddenClassName} ${classes.source}`}
             >
               {sourceLink && (
                 <A className={classes.sourceLink} href={sourceLink}>

--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -10,6 +10,20 @@ import aggregateData, { isSelectFunc } from './utils/aggregateData';
 import propTypes from '../core/propTypes';
 import withVictoryTheme from '../core/styles/withVictoryTheme';
 
+function sanitizeChartProps(chartProps) {
+  const sanitizedProps = {};
+  Object.keys(chartProps).forEach(key => {
+    /**
+     * These props are computed
+     * Avoid spreading (overriding) them to the charts
+     */
+    if (!['height', 'width', 'offset'].includes(key)) {
+      sanitizedProps[key] = chartProps[key];
+    }
+  });
+  return sanitizedProps;
+}
+
 function ChartFactory({
   theme,
   definition: {
@@ -38,7 +52,10 @@ function ChartFactory({
   comparisonData,
   referenceData,
   profiles,
-  ...visualProps
+  /**
+   * Custom properties to apply to the chart
+   */
+  ...chartProps
 }) {
   const key =
     id ||
@@ -209,13 +226,14 @@ function ChartFactory({
                   label: referenceLabel
                 }
               ]}
+              {...sanitizeChartProps(chartProps)}
             />
           </div>
         );
       }
       case 'pie': {
-        const height = visualProps.height || theme.pie.height;
-        const width = visualProps.width || theme.pie.width;
+        const height = chartProps.height || theme.pie.height;
+        const width = chartProps.width || theme.pie.width;
 
         return (
           <div style={{ height, width }}>
@@ -227,6 +245,7 @@ function ChartFactory({
               theme={theme}
               width={width}
               height={height}
+              {...sanitizeChartProps(chartProps)}
             />
           </div>
         );
@@ -262,12 +281,13 @@ function ChartFactory({
             description={`${description} ${xDesc}`}
             comparisonData={[]} // TODO: pending NumberVisuals components (HURUmap-UI) fix on this propTypes
             classes={{}} // TODO: pending NumberVisuals style configurations - update root margin
+            {...sanitizeChartProps(chartProps)}
           />
         );
       }
       case 'grouped_column': {
         const barCount = primaryData[0].length;
-        const offset = visualProps.offset || theme.bar.offset;
+        const offset = chartProps.offset || theme.bar.offset;
         const {
           domainPadding: {
             x: [x0, x1]
@@ -280,8 +300,8 @@ function ChartFactory({
           primaryData.length * barCount * offset +
           domainPadding.x[0] +
           domainPadding.x[1];
-        const height = visualProps.height || theme.bar.height;
-        const width = visualProps.width || theme.bar.width;
+        const height = chartProps.height || theme.bar.height;
+        const width = chartProps.width || theme.bar.width;
         const computedHorizontal = computedSize > width || horizontal;
         const computedWidth = computedHorizontal ? width : computedSize;
         const computedHeight = computedHorizontal ? computedSize : height;
@@ -319,13 +339,14 @@ function ChartFactory({
                 }
               }}
               theme={theme}
+              {...sanitizeChartProps(chartProps)}
             />
           </div>
         );
       }
       case 'column': {
         const barCount = isComparison ? 2 : 1;
-        const offset = visualProps.offset || theme.bar.offset;
+        const offset = chartProps.offset || theme.bar.offset;
         const {
           domainPadding: {
             x: [x0, x1]
@@ -338,8 +359,8 @@ function ChartFactory({
           domainPadding.x[1] +
           // Bug when 2 bars only
           (primaryData.length === 2 ? offset : 0);
-        const height = visualProps.height || theme.bar.height;
-        const width = visualProps.width || theme.bar.width;
+        const height = chartProps.height || theme.bar.height;
+        const width = chartProps.width || theme.bar.width;
         const computedHorizontal = computedSize > width || horizontal;
         const computedWidth = computedHorizontal ? width : computedSize;
         const computedHeight = computedHorizontal ? computedSize : height;
@@ -381,6 +402,7 @@ function ChartFactory({
                   }
                 }}
                 theme={theme}
+                {...sanitizeChartProps(chartProps)}
               />
             </div>
           );
@@ -420,6 +442,7 @@ function ChartFactory({
                 }
               }}
               theme={theme}
+              {...sanitizeChartProps(chartProps)}
             />
           </div>
         );
@@ -449,6 +472,11 @@ ChartFactory.propTypes = {
   definition: propTypes.shape({
     id: propTypes.string,
     type: propTypes.string,
+    /**
+     * Custom chart props
+     * These props override any default or computated values
+     */
+    props: propTypes.shape({}),
     label: propTypes.string,
     reference: propTypes.shape({ label: propTypes.string }),
     aggregate: propTypes.string,

--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -18,7 +18,7 @@ function sanitizeChartProps(chartProps, mergeProps) {
      * These props are computed
      * Avoid spreading (overriding) them to the charts
      */
-    if (!['height', 'width', 'offset'].includes(key)) {
+    if (!['horizontal', 'height', 'width', 'offset'].includes(key)) {
       sanitizedProps[key] = chartProps[key];
     }
   });
@@ -303,7 +303,8 @@ function ChartFactory({
           domainPadding.x[1];
         const height = chartProps.height || theme.bar.height;
         const width = chartProps.width || theme.bar.width;
-        const computedHorizontal = computedSize > width || horizontal;
+        const computedHorizontal =
+          computedSize > width || chartProps.horizontal || horizontal;
         const computedWidth = computedHorizontal ? width : computedSize;
         const computedHeight = computedHorizontal ? computedSize : height;
 
@@ -363,7 +364,8 @@ function ChartFactory({
           (primaryData.length === 2 ? offset : 0);
         const height = chartProps.height || theme.bar.height;
         const width = chartProps.width || theme.bar.width;
-        const computedHorizontal = computedSize > width || horizontal;
+        const computedHorizontal =
+          computedSize > width || chartProps.horizontal || horizontal;
         const computedWidth = computedHorizontal ? width : computedSize;
         const computedHeight = computedHorizontal ? computedSize : height;
         if (isComparison) {

--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef, useState, useCallback } from 'react';
 
 import { Box, ButtonBase } from '@material-ui/core';
+import _ from 'lodash';
 import BarChart from '../core/BarChart';
 import PieChart from '../core/PieChart';
 import NestedProportionalAreaChart from '../core/NestedProportionalAreaChart';
@@ -10,7 +11,7 @@ import aggregateData, { isSelectFunc } from './utils/aggregateData';
 import propTypes from '../core/propTypes';
 import withVictoryTheme from '../core/styles/withVictoryTheme';
 
-function sanitizeChartProps(chartProps) {
+function sanitizeChartProps(chartProps, mergeProps) {
   const sanitizedProps = {};
   Object.keys(chartProps).forEach(key => {
     /**
@@ -21,7 +22,7 @@ function sanitizeChartProps(chartProps) {
       sanitizedProps[key] = chartProps[key];
     }
   });
-  return sanitizedProps;
+  return _.merge(mergeProps || {}, sanitizedProps);
 }
 
 function ChartFactory({
@@ -317,29 +318,30 @@ function ChartFactory({
               horizontal={computedHorizontal}
               domainPadding={domainPadding}
               labels={({ datum }) => formatLabelValue(datum.y)}
-              parts={{
-                axis: {
-                  independent: {
-                    style: {
-                      axis: {
-                        display: 'block'
-                      },
-                      tickLabels: {
-                        display: 'block'
+              theme={theme}
+              {...sanitizeChartProps(chartProps, {
+                parts: {
+                  axis: {
+                    independent: {
+                      style: {
+                        axis: {
+                          display: 'block'
+                        },
+                        tickLabels: {
+                          display: 'block'
+                        }
                       }
-                    }
-                  },
-                  dependent: {
-                    style: {
-                      grid: {
-                        display: 'block'
+                    },
+                    dependent: {
+                      style: {
+                        grid: {
+                          display: 'block'
+                        }
                       }
                     }
                   }
                 }
-              }}
-              theme={theme}
-              {...sanitizeChartProps(chartProps)}
+              })}
             />
           </div>
         );
@@ -380,7 +382,50 @@ function ChartFactory({
                 horizontal={computedHorizontal}
                 domainPadding={domainPadding}
                 labels={({ datum }) => formatLabelValue(datum.y)}
-                parts={{
+                theme={theme}
+                {...sanitizeChartProps(chartProps, {
+                  parts: {
+                    axis: {
+                      independent: {
+                        style: {
+                          axis: {
+                            display: 'block'
+                          },
+                          tickLabels: {
+                            display: 'block'
+                          }
+                        }
+                      },
+                      dependent: {
+                        style: {
+                          grid: {
+                            display: 'block'
+                          }
+                        }
+                      }
+                    }
+                  }
+                })}
+              />
+            </div>
+          );
+        }
+        return (
+          <div style={{ width: computedWidth, height: computedHeight }}>
+            <BarChart
+              key={key}
+              data={primaryData}
+              offset={offset}
+              height={computedHeight}
+              width={computedWidth}
+              horizontal={computedHorizontal}
+              domainPadding={domainPadding}
+              labels={({ datum }) => {
+                return formatLabelValue(datum.y);
+              }}
+              theme={theme}
+              {...sanitizeChartProps(chartProps, {
+                parts: {
                   axis: {
                     independent: {
                       style: {
@@ -400,49 +445,8 @@ function ChartFactory({
                       }
                     }
                   }
-                }}
-                theme={theme}
-                {...sanitizeChartProps(chartProps)}
-              />
-            </div>
-          );
-        }
-        return (
-          <div style={{ width: computedWidth, height: computedHeight }}>
-            <BarChart
-              key={key}
-              data={primaryData}
-              offset={offset}
-              height={computedHeight}
-              width={computedWidth}
-              horizontal={computedHorizontal}
-              domainPadding={domainPadding}
-              labels={({ datum }) => {
-                return formatLabelValue(datum.y);
-              }}
-              parts={{
-                axis: {
-                  independent: {
-                    style: {
-                      axis: {
-                        display: 'block'
-                      },
-                      tickLabels: {
-                        display: 'block'
-                      }
-                    }
-                  },
-                  dependent: {
-                    style: {
-                      grid: {
-                        display: 'block'
-                      }
-                    }
-                  }
                 }
-              }}
-              theme={theme}
-              {...sanitizeChartProps(chartProps)}
+              })}
             />
           </div>
         );

--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -1,7 +1,7 @@
 import React, { useMemo, useRef, useState, useCallback } from 'react';
 
 import { Box, ButtonBase } from '@material-ui/core';
-import _ from 'lodash';
+
 import BarChart from '../core/BarChart';
 import PieChart from '../core/PieChart';
 import NestedProportionalAreaChart from '../core/NestedProportionalAreaChart';
@@ -311,29 +311,7 @@ function ChartFactory({
               domainPadding={domainPadding}
               labels={({ datum }) => formatLabelValue(datum.y)}
               theme={theme}
-              {..._.merge(chartProps, {
-                parts: {
-                  axis: {
-                    independent: {
-                      style: {
-                        axis: {
-                          display: 'block'
-                        },
-                        tickLabels: {
-                          display: 'block'
-                        }
-                      }
-                    },
-                    dependent: {
-                      style: {
-                        grid: {
-                          display: 'block'
-                        }
-                      }
-                    }
-                  }
-                }
-              })}
+              {...chartProps}
             />
           </div>
         );
@@ -375,29 +353,7 @@ function ChartFactory({
                 domainPadding={domainPadding}
                 labels={({ datum }) => formatLabelValue(datum.y)}
                 theme={theme}
-                {..._.merge(chartProps, {
-                  parts: {
-                    axis: {
-                      independent: {
-                        style: {
-                          axis: {
-                            display: 'block'
-                          },
-                          tickLabels: {
-                            display: 'block'
-                          }
-                        }
-                      },
-                      dependent: {
-                        style: {
-                          grid: {
-                            display: 'block'
-                          }
-                        }
-                      }
-                    }
-                  }
-                })}
+                {...chartProps}
               />
             </div>
           );
@@ -416,29 +372,7 @@ function ChartFactory({
                 return formatLabelValue(datum.y);
               }}
               theme={theme}
-              {..._.merge(chartProps, {
-                parts: {
-                  axis: {
-                    independent: {
-                      style: {
-                        axis: {
-                          display: 'block'
-                        },
-                        tickLabels: {
-                          display: 'block'
-                        }
-                      }
-                    },
-                    dependent: {
-                      style: {
-                        grid: {
-                          display: 'block'
-                        }
-                      }
-                    }
-                  }
-                }
-              })}
+              {...chartProps}
             />
           </div>
         );

--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -13,7 +13,7 @@ import withVictoryTheme from '../core/styles/withVictoryTheme';
 
 function sanitizeChartProps(chartProps, mergeProps) {
   const sanitizedProps = {};
-  Object.keys(chartProps).forEach(key => {
+  Object.keys(chartProps || {}).forEach(key => {
     /**
      * These props are computed
      * Avoid spreading (overriding) them to the charts

--- a/stories/container.stories.js
+++ b/stories/container.stories.js
@@ -133,34 +133,7 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
                       }))}
                     parts={{
                       axis: {
-                        independent: {
-                          style: {
-                            axis: {
-                              display: 'block'
-                            },
-                            grid: {
-                              display: 'block'
-                            },
-                            ticks: {
-                              display: 'block'
-                            },
-                            tickLabels: {
-                              display: 'block'
-                            }
-                          }
-                        },
                         dependent: {
-                          style: {
-                            axis: {
-                              display: 'block'
-                            },
-                            grid: {
-                              display: 'block'
-                            },
-                            tickLabels: {
-                              display: 'block'
-                            }
-                          },
                           tickValues: [10, 50, 90],
                           tickFormat: ['10%', '50%', '90%']
                         }
@@ -253,26 +226,16 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
                 horizontal={boolean('horizontal', false)}
                 width={500}
                 height={300}
-                data={Array(number('data', 100))
+                data={Array(number('data', 10))
                   .fill(null)
                   .map((_, index) => ({
                     x: `${index}-${index}`,
                     y: rand()
                   }))}
+                domainPadding={{ x: 40 }}
                 parts={{
                   axis: {
                     dependent: {
-                      style: {
-                        axis: {
-                          display: 'block'
-                        },
-                        grid: {
-                          display: 'block'
-                        },
-                        tickLabels: {
-                          display: 'block'
-                        }
-                      },
                       tickValues: [10, 50, 90],
                       tickFormat: ['10%', '50%', '90%']
                     }
@@ -359,14 +322,17 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
           >
             <ChartFactory definition={statisticDefinition} data={dataArray} />
             <ChartFactory
-              definition={definition}
+              definition={{
+                ...definition,
+                typeProps: {
+                  height: chartHeight,
+                  width:
+                    variant === 'analysis' && !chartWidth
+                      ? containerWidth
+                      : chartWidth
+                }
+              }}
               data={dataArray}
-              height={chartHeight}
-              width={
-                variant === 'analysis' && !chartWidth
-                  ? containerWidth
-                  : chartWidth
-              }
             />
           </InsightContainer>
         </div>

--- a/stories/factory.stories.js
+++ b/stories/factory.stories.js
@@ -21,7 +21,6 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
     const type = select('type', ['column', 'number', 'pie'], 'column');
     const horizontal = boolean('horizontal');
     const data = Array(number('data', 3)).fill(null);
-    // const aggregate = select('aggregate', ['sum', 'avg', 'sum:percent'], 'sum');
     const unit = text('unit', 'u');
     const subtitle = text('subtitle', 'Subtitle');
     const description = text('description', 'Description');
@@ -30,7 +29,6 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
     });
     const statistic = object('statistic', {
       unit: '%',
-      // aggregate: 'sum:percent',
       unique: true
     });
 
@@ -41,7 +39,6 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
           typeProps: {
             horizontal
           },
-          // aggregate,
           unit,
           subtitle,
           description,

--- a/stories/factory.stories.js
+++ b/stories/factory.stories.js
@@ -21,7 +21,7 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
     const type = select('type', ['column', 'number', 'pie'], 'column');
     const horizontal = boolean('horizontal');
     const data = Array(number('data', 3)).fill(null);
-    const aggregate = select('aggregate', ['sum', 'avg', 'sum:percent'], 'sum');
+    // const aggregate = select('aggregate', ['sum', 'avg', 'sum:percent'], 'sum');
     const unit = text('unit', 'u');
     const subtitle = text('subtitle', 'Subtitle');
     const description = text('description', 'Description');
@@ -30,7 +30,7 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
     });
     const statistic = object('statistic', {
       unit: '%',
-      aggregate: 'sum:percent',
+      // aggregate: 'sum:percent',
       unique: true
     });
 
@@ -38,12 +38,14 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
       <ChartFactory
         definition={{
           type,
-          aggregate,
+          typeProps: {
+            horizontal
+          },
+          // aggregate,
           unit,
           subtitle,
           description,
-          statistic,
-          horizontal
+          statistic
         }}
         data={data.map((_, index) => {
           const y = rand();
@@ -60,12 +62,12 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
   .add('Grouped', () => {
     const type = select('type', ['grouped_column', 'number'], 'grouped_column');
     const horizontal = boolean('horizontal');
-    const groups = number('groups', 3);
-    const data = Array(number('data', 3) * groups).fill(null);
+    const groups = number('groups', 2);
+    const data = Array(number('data', 2) * groups).fill(null);
     const aggregate = select(
       'aggregate',
       ['sum', 'avg', 'sum:percent', ''],
-      'sum:percent'
+      ''
     );
     const unit = text('unit', '%');
     const subtitle = text('subtitle', 'Subtitle');
@@ -84,12 +86,15 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
       <ChartFactory
         definition={{
           type,
+          typeProps: {
+            ...props,
+            horizontal
+          },
           aggregate,
           unit,
           subtitle,
           description,
-          statistic,
-          horizontal
+          statistic
         }}
         data={data.map((_, index) => {
           const y = rand();
@@ -100,7 +105,6 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
             y
           };
         })}
-        {...props}
       />
     );
   })


### PR DESCRIPTION
## Description

Solution: 
Pass the props as `<ChartFactory ... {...chart.visual.props} />`

Problem:
In `charts.json`, each **visual** has a `props` attribute where one can specify all chart customization they need. For example:
```
...
  props: {
   parts: {
     legend: {
        size: 100,
     }
   },
    offset: 20,
   }
....

```

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation