### PR TITLE
[Hotfix] Chart container source could be "undefined"

### DIFF
--- a/src/core/ChartContainer/index.js
+++ b/src/core/ChartContainer/index.js
@@ -401,7 +401,9 @@ function ChartContainer({
         className={classes.attribution}
       >
         <Grid item className={classes.attributionSource}>
-          <Typography variant="caption">{`Source ${sourceLink}`}</Typography>
+          {sourceLink && (
+            <Typography variant="caption">{`Source ${sourceLink}`}</Typography>
+          )}
         </Grid>
         <Grid item className={classes.attributionLogo}>
           <img src={logo} alt="log" />

--- a/src/core/InsightContainer/index.js
+++ b/src/core/InsightContainer/index.js
@@ -247,7 +247,7 @@ function InsightContainer({
             component="span"
             className={`${classes.sourceGrid} ${downloadHiddenClassName}`}
           >
-            {source && source.href && (
+            {source && (
               <A className={classes.sourceLink} href={source.href}>
                 {`Source: ${source.title || source.href}`}
               </A>
@@ -302,7 +302,7 @@ function InsightContainer({
         className={classes.attribution}
       >
         <Grid item className={classes.attributionSource}>
-          <Typography variant="caption">{`Source ${source.href}`}</Typography>
+          {source && <Typography variant="caption">{`Source ${source.href}`}</Typography>}
         </Grid>
         <Grid item className={classes.attributionLogo}>
           <img src={logo} alt="logo" />

--- a/src/core/InsightContainer/index.js
+++ b/src/core/InsightContainer/index.js
@@ -247,7 +247,7 @@ function InsightContainer({
             component="span"
             className={`${classes.sourceGrid} ${downloadHiddenClassName}`}
           >
-            {source && (
+            {source && source.href && (
               <A className={classes.sourceLink} href={source.href}>
                 {`Source: ${source.title || source.href}`}
               </A>

--- a/src/core/InsightContainer/index.js
+++ b/src/core/InsightContainer/index.js
@@ -302,7 +302,9 @@ function InsightContainer({
         className={classes.attribution}
       >
         <Grid item className={classes.attributionSource}>
-          {source && <Typography variant="caption">{`Source ${source.href}`}</Typography>}
+          {source && (
+            <Typography variant="caption">{`Source ${source.href}`}</Typography>
+          )}
         </Grid>
         <Grid item className={classes.attributionLogo}>
           <img src={logo} alt="logo" />
@@ -350,7 +352,7 @@ InsightContainer.propTypes = {
   loading: PropTypes.bool,
   source: PropTypes.shape({
     title: PropTypes.string,
-    href: PropTypes.string
+    href: PropTypes.string.isRequired
   }),
   title: PropTypes.string.isRequired,
   variant: PropTypes.oneOf(['data', 'analysis'])


### PR DESCRIPTION
## Description

Chart containers break if source is undefined

 - [x] Fix `InsightChartContainer`, and
 - [x] Fix `ChartContainer`
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

### Bug
![Screenshot from 2019-11-11 12-12-43](https://user-images.githubusercontent.com/7962097/68576056-68de2200-047e-11ea-915e-ff56068cc7ed.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation