### PR TITLE
[Hotfix] Default InsightChartContainer actions & their customizability

### DIFF
--- a/src/core/InsightContainer/Action/index.js
+++ b/src/core/InsightContainer/Action/index.js
@@ -16,7 +16,7 @@ import BlockLoader from '../../BlockLoader';
 
 const useStyles = makeStyles({
   root: {
-    width: '100%',
+    width: 'auto',
     maxWidth: '21.75rem',
     overflow: 'hidden',
     backgroundColor: 'white',
@@ -41,10 +41,12 @@ const useStyles = makeStyles({
     letterSpacing: '0.019rem'
   },
   verticalDivider: {
-    margin: 'auto 0',
-    width: '0.07rem',
-    height: '1.913rem',
-    backgroundColor: '#eaeaea'
+    '&:not(:first-of-type)': {
+      margin: 'auto 0',
+      width: '0.07rem',
+      height: '1.913rem',
+      backgroundColor: '#eaeaea'
+    }
   },
   iconGrid: {
     height: '2.1875rem'
@@ -76,17 +78,22 @@ function Actions({
     <Grid container justify="space-evenly" className={classes.root}>
       <BlockLoader loading={loading} height={40}>
         {onShare && (
-          <ActionButton
-            gaEvents={share}
-            onClick={onShare}
-            classes={{
-              actionButton: classes.shareButton,
-              iconGrid: classes.actionButtonIconGrid
-            }}
-          >
-            <img alt="" src={shareIcon} />
-            <Typography className={classes.actionButtonText}>Share</Typography>
-          </ActionButton>
+          <>
+            <div className={classes.verticalDivider} />
+            <ActionButton
+              gaEvents={share}
+              onClick={onShare}
+              classes={{
+                actionButton: classes.shareButton,
+                iconGrid: classes.actionButtonIconGrid
+              }}
+            >
+              <img alt="" src={shareIcon} />
+              <Typography className={classes.actionButtonText}>
+                Share
+              </Typography>
+            </ActionButton>
+          </>
         )}
 
         {onDownload && (

--- a/src/core/InsightContainer/index.js
+++ b/src/core/InsightContainer/index.js
@@ -116,7 +116,7 @@ function InsightContainer({
     handleCompare,
     handleDownload: handleDownloadProp,
     handleShowData
-  } = actions;
+  } = actions || {};
 
   const [rootNode, setRootNode] = useState();
 
@@ -154,8 +154,11 @@ function InsightContainer({
       document.body.removeChild(link);
     }
   };
+  // null should disable action
+  const handleDownload =
+    handleDownloadProp ||
+    (handleDownloadProp === undefined ? defaultHandleDownload : undefined);
 
-  const handleDownload = handleDownloadProp || defaultHandleDownload;
   const actionsChildren = (
     <Actions
       loading={loading}
@@ -361,12 +364,7 @@ InsightContainer.propTypes = {
 
 InsightContainer.defaultProps = {
   hideInsight: false,
-  actions: {
-    handleShare: () => {},
-    handleDownload: undefined,
-    handleShowData: () => {},
-    handleCompare: () => {}
-  },
+  actions: undefined,
   embedCode: undefined,
   gaEvents: undefined,
   insight: undefined,

--- a/stories/container.stories.js
+++ b/stories/container.stories.js
@@ -300,9 +300,9 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
       return (
         <div style={{ width: containerWidth }}>
           <InsightContainer
-            hideInsight={hideInsight}
             classes={{ root: classes.root }}
             embedCode={text('embedCode', 'Embed Chart Code')}
+            hideInsight={hideInsight}
             insight={object('insight', {
               analysisLink: '#',
               dataLink: '#',
@@ -311,13 +311,13 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
               title: 'Summary'
             })}
             loading={boolean('loading', false)}
+            logo={logo}
             source={object('source', {
               title: 'Community Survey 2016',
               href: 'http://dev.dominion.africa'
             })}
             title="Lorem ipsum dolor sit amet"
             variant={variant}
-            logo={logo}
           >
             <ChartFactory definition={statisticDefinition} data={dataArray} />
             <ChartFactory
@@ -330,6 +330,88 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
                       ? containerWidth
                       : chartWidth
                 }
+              }}
+              data={dataArray}
+            />
+          </InsightContainer>
+        </div>
+      );
+    })
+  )
+  .add('Custom', () =>
+    React.createElement(() => {
+      const useStyles = makeStyles(() => ({
+        root: {
+          backgroundColor: '#f6f6f6'
+        }
+      }));
+      const classes = useStyles();
+
+      const containerWidth = 950;
+      const variant = 'data';
+      const groups = 3;
+      const data = 2;
+      const dataExponent = 6;
+      const statisticDefinition = {
+        type: 'number',
+        style: 'percent',
+        subtitle: 'Lorem ipsum',
+        description: 'Lorem ipsum dolor sit amet',
+        aggregate: 'last:percent'
+      };
+      const definition = {
+        type: 'grouped_column',
+        horizontal: false,
+        customUnit: 'km²',
+        groupBy: 'Group',
+        aggregate: 'raw'
+      };
+
+      const dataArray = Array(((definition.groupBy && groups) || 1) * data)
+        .fill(null)
+        .map((_, index) => ({
+          groupBy:
+            definition.groupBy && `${definition.groupBy} ${index % groups}`,
+          x: `Data ${index}`,
+          y: rand() * 10 ** dataExponent
+        }));
+      const share = boolean('Share', true);
+      const download = boolean('Download', true);
+      const embed = boolean('Embed', true);
+      const compare = boolean('Compare', true);
+      const showData = boolean('Show Data', true);
+
+      return (
+        <div style={{ width: containerWidth }}>
+          <InsightContainer
+            actions={{
+              handleShare: share ? () => {} : undefined,
+              // For download, undefined means use default
+              handleDownload: download ? undefined : null,
+              handleShowData: showData ? () => {} : undefined,
+              handleCompare: compare ? () => {} : undefined
+            }}
+            classes={{ root: classes.root }}
+            embedCode={embed ? 'Embed Chart Code' : undefined}
+            insight={{
+              analysisLink: '#',
+              dataLink: '#',
+              description:
+                'Ethnically diverse population of over 55 million Country benefits from broad social cohesion, with inter-ethtensions rare Two thirds of the population live on lethan $2 per day - espcially rural areas',
+              title: 'Summary'
+            }}
+            logo={logo}
+            source={{
+              title: 'Community Survey 2016',
+              href: 'http://dev.takwimu.africa'
+            }}
+            title="Lorem ipsum dolor sit amet"
+            variant={variant}
+          >
+            <ChartFactory definition={statisticDefinition} data={dataArray} />
+            <ChartFactory
+              definition={{
+                ...definition
               }}
               data={dataArray}
             />


### PR DESCRIPTION
## Description

Default:

- [x] **Download** is the only action with default handler,
- [x] **Embed** should only be active if _embed code_ is provided.

Customization:
- [x] If no handler, action should not be active, and
- [x] Passing `null` for `onDownload` should disable even the default action.

We need this behaviour to support Florish charts on the front-end since they don't have actions like `Show Data` or `Compare`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Peek 2019-11-14 15-35](https://user-images.githubusercontent.com/1779590/68858068-40139200-06f5-11ea-98e2-53c0cb61bb0c.gif)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation