### PR TITLE
[Bug] Fix analysis link title prop

### DIFF
--- a/src/core/InsightContainer/Insight.js
+++ b/src/core/InsightContainer/Insight.js
@@ -71,10 +71,12 @@ function Insight({
       : analysisLinkProp;
   if (analysisLink) {
     analysisLink.variant = analysisLink.variant || 'contained';
-    analysisLink.title =
-      analysisLink.title || analysisLink.variant === 'contained'
-        ? 'Read the full analysis'
-        : 'Read the country analysis';
+    if (!analysisLink.title) {
+      analysisLink.title =
+        analysisLink.variant === 'contained'
+          ? 'Read the full analysis'
+          : 'Read the country analysis';
+    }
   }
   const dataLink =
     dataLinkProp && typeof dataLinkProp === 'string'

--- a/src/core/InsightContainer/Insight.js
+++ b/src/core/InsightContainer/Insight.js
@@ -84,6 +84,7 @@ function Insight({
       : dataLinkProp;
   if (dataLink) {
     dataLink.variant = dataLink.variant || 'outlined';
+    dataLink.title = dataLink.title || 'View more data by topic';
   }
 
   return (

--- a/stories/container.stories.js
+++ b/stories/container.stories.js
@@ -402,8 +402,24 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
             classes={{ root: classes.root }}
             embedCode={embed ? 'Embed Chart Code' : undefined}
             insight={{
-              analysisLink: '#',
-              dataLink: '#',
+              analysisLink: {
+                href: text('Analysis link url', '#'),
+                title: text('Analysis link title', 'Read country analysis'),
+                variant: select(
+                  'Analysis link variant',
+                  ['contained', 'outlined'],
+                  'contained'
+                )
+              },
+              dataLink: {
+                href: text('Data link url', '#'),
+                title: text('Data link title', 'View country data'),
+                variant: select(
+                  'Data link variant',
+                  ['contained', 'outlined'],
+                  'outlined'
+                )
+              },
               description:
                 'Ethnically diverse population of over 55 million Country benefits from broad social cohesion, with inter-ethtensions rare Two thirds of the population live on lethan $2 per day - espcially rural areas',
               title: 'Summary'


### PR DESCRIPTION
## Description

Analysis link title on insight container does not update to the custom prop sent. This PR fixes that

![69143161-6eb8b080-0ad9-11ea-89e3-12a3e042f2d3](https://user-images.githubusercontent.com/7962097/69412003-1ecb2b00-0d1f-11ea-998b-93e83d7d0ce4.png)


Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation