### PR TITLE
Standardize Tooltips + Fix some warnings

### DIFF
--- a/src/core/ActionButton.js
+++ b/src/core/ActionButton.js
@@ -21,9 +21,15 @@ function ActionButton({
   children,
   onClick,
   gaEvents: { gaOn, gaEventAction, gaEventCategory, gaEventLabel },
+  classes: propClasses,
   ...props
 }) {
-  const classes = useStyles(props);
+  const classes = useStyles({
+    classes: {
+      actionButton: propClasses.actionButton,
+      iconGrid: propClasses.iconGrid
+    }
+  });
   return (
     <IconButton
       className={classes.actionButton}

--- a/src/core/BarChart/BarLabel.js
+++ b/src/core/BarChart/BarLabel.js
@@ -3,27 +3,33 @@ import PropTypes from 'prop-types';
 
 import { VictoryLabel } from 'victory';
 
+import { labels as defaultLabels } from '../utils';
 import Tooltip from '../Tooltip';
 
 function BarLabel({
   datum,
+  labels: labelsProp,
   text,
   tooltipProps: { data, ...tooltipProps },
   x,
   y,
   ...props
 }) {
+  const labels = labelsProp || defaultLabels;
+  let tooltip = text;
+  // eslint-disable-next-line no-underscore-dangle
+  if (data && datum && data[datum._x - 1]) {
+    // eslint-disable-next-line no-underscore-dangle
+    tooltip = data[datum._x - 1].tooltip || labels(data[datum._x - 1]);
+  }
+
   return (
     <>
       <VictoryLabel datum={datum} text={text} {...props} />
       <Tooltip
         {...tooltipProps}
         datum={datum}
-        text={
-          // eslint-disable-next-line no-underscore-dangle
-          (data && datum && data[datum._x - 1] && data[datum._x - 1].tooltip) ||
-          text
-        }
+        text={tooltip}
         x={x}
         y={y}
         // eslint-disable-next-line react/prop-types, no-underscore-dangle
@@ -35,6 +41,7 @@ function BarLabel({
 
 BarLabel.propTypes = {
   datum: PropTypes.shape({ _x: PropTypes.number }),
+  labels: PropTypes.func,
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   tooltipProps: PropTypes.shape({
     data: PropTypes.arrayOf(
@@ -54,6 +61,7 @@ BarLabel.defaultEvents = Tooltip.defaultEvents;
 
 BarLabel.defaultProps = {
   datum: undefined,
+  labels: undefined,
   text: undefined,
   x: undefined,
   y: undefined

--- a/src/core/BulletChart/BulletBar.js
+++ b/src/core/BulletChart/BulletBar.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { Border, Rect, Selection, VictoryLabel, VictoryTooltip } from 'victory';
+
 import propTypes from '../propTypes';
 
 function BulletBar({
@@ -16,11 +17,11 @@ function BulletBar({
   x,
   y
 }) {
-  const featuredMeasure = (width * data[0].x) / total;
+  const featuredMeasure = (width * data[0].y) / total;
   const [tooltipProps, setTooltipProps] = useState({});
   const [, qualitativeMeasureProp] = data;
-  const qualitativeMeasure = qualitativeMeasureProp || { x: total };
-  const comparativeMeasure = (width * reference.data[0].x) / total;
+  const qualitativeMeasure = qualitativeMeasureProp || { y: total };
+  const comparativeMeasure = (width * reference.data[0].y) / total;
 
   const tooltip = (
     <VictoryTooltip constrainToVisibleArea {...tooltipProps} theme={theme} />
@@ -35,27 +36,31 @@ function BulletBar({
   return (
     <>
       {/* Qualitative scale */}
-      <VictoryLabel
-        capHeight={0}
-        lineHeight={0}
-        textAnchor="end"
-        x={x + width}
-        y={y - 2 * barWidth}
-        text={labels(qualitativeMeasure)}
-        style={style.labels}
-      />
+      {qualitativeMeasureProp && (
+        <VictoryLabel
+          capHeight={0}
+          lineHeight={0}
+          textAnchor="end"
+          x={x + width}
+          y={y - 2 * barWidth}
+          text={labels(qualitativeMeasure)}
+          style={style.labels}
+        />
+      )}
       <Border
-        events={{
-          onMouseOver: evt =>
-            activateTooltip(evt, {
-              text: labels(qualitativeMeasure)
-            }),
-          onMouseMove: evt =>
-            activateTooltip(evt, {
-              text: labels(qualitativeMeasure)
-            }),
-          onMouseOut: () => setTooltipProps({ active: false })
-        }}
+        events={
+          qualitativeMeasureProp && {
+            onMouseOver: evt =>
+              activateTooltip(evt, {
+                text: labels(qualitativeMeasure)
+              }),
+            onMouseMove: evt =>
+              activateTooltip(evt, {
+                text: labels(qualitativeMeasure)
+              }),
+            onMouseOut: () => setTooltipProps({ active: false })
+          }
+        }
         x={x}
         y={y - barWidth}
         width={width}

--- a/src/core/BulletChart/index.js
+++ b/src/core/BulletChart/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { labels as defaultLabels } from '../utils';
 import { toReferenceProps } from '../ReferableChart';
 import withVictoryTheme from '../styles/withVictoryTheme';
 import BulletBar from './BulletBar';
@@ -66,7 +67,7 @@ function BulletChart({
           <BulletBar
             barWidth={computedBarWidth}
             data={d}
-            labels={labels || (() => '')}
+            labels={labels || defaultLabels}
             reference={reference}
             style={{
               ...computedStyle,

--- a/src/core/ComparisonBarChart.js
+++ b/src/core/ComparisonBarChart.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Border, Selection, VictoryLabel, VictoryTooltip } from 'victory';
 
+import { labels as defaultLabels } from './utils';
 import propTypes from './propTypes';
 import { toReferenceProps } from './ReferableChart';
 import withVictoryTheme from './styles/withVictoryTheme';
@@ -13,6 +14,7 @@ function ComparisonBarChart({
   data,
   height: heightProp,
   horizontal = true,
+  labels: labelsProp,
   reference: referenceProp,
   style = {},
   theme,
@@ -38,6 +40,7 @@ function ComparisonBarChart({
   const dataBarWidths = data.map(d => (d.y * width) / max);
   const referenceDataBarWidth = (referenceData.y * width) / max;
   const barHeight = barHeightProp || chart.barHeight;
+  const labels = labelsProp || defaultLabels;
 
   const tooltip = (
     <VictoryTooltip constrainToVisibleArea {...tooltipProps} theme={theme} />
@@ -70,9 +73,9 @@ function ComparisonBarChart({
           <Border
             events={{
               onMouseOver: evt =>
-                activateTooltip(evt, { text: `${data[i].x}: ${data[i].y}` }),
+                activateTooltip(evt, { text: labels(data[i]) }),
               onMouseMove: evt =>
-                activateTooltip(evt, { text: `${data[i].x}: ${data[i].y}` }),
+                activateTooltip(evt, { text: labels(data[i]) }),
               onMouseOut: () => setTooltipProps({ active: false })
             }}
             height={barHeight}
@@ -96,11 +99,11 @@ function ComparisonBarChart({
         events={{
           onMouseOver: evt =>
             activateTooltip(evt, {
-              text: `${referenceData.x}: ${referenceData.y}`
+              text: labels(referenceData)
             }),
           onMouseMove: evt =>
             activateTooltip(evt, {
-              text: `${referenceData.x}: ${referenceData.y}`
+              text: labels(referenceData)
             }),
           onMouseOut: () => setTooltipProps({ active: false })
         }}
@@ -131,6 +134,7 @@ ComparisonBarChart.propTypes = {
   ).isRequired,
   height: PropTypes.number,
   horizontal: PropTypes.bool,
+  labels: propTypes.func,
   reference: propTypes.reference,
   style: PropTypes.shape({
     data: PropTypes.shape({}),
@@ -144,6 +148,7 @@ ComparisonBarChart.defaultProps = {
   barHeight: undefined,
   height: undefined,
   horizontal: undefined,
+  labels: undefined,
   reference: undefined,
   style: undefined,
   theme: undefined,

--- a/src/core/EmbedDropDown.js
+++ b/src/core/EmbedDropDown.js
@@ -69,7 +69,7 @@ EmbedDropDown.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired,
-  anchorEl: PropTypes.shape({}).isRequired,
+  anchorEl: PropTypes.shape({}),
   onClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
   subtitle: PropTypes.string,
@@ -77,6 +77,7 @@ EmbedDropDown.propTypes = {
 };
 
 EmbedDropDown.defaultProps = {
+  anchorEl: null,
   open: undefined,
   subtitle: null,
   title: null

--- a/src/core/Label.js
+++ b/src/core/Label.js
@@ -72,14 +72,13 @@ function Label({
 }) {
   const [style, setStyle] = useState(originalStyle);
   const [text, setText] = useState(null);
-  const [wrappedText, setWrappedText] = useState(null);
   const canvas = useMemo(() => document.createElement('canvas'), []);
-  useEffect(() => {
+  const wrappedText = useMemo(() => {
+    let wrapped = [];
     if (originalText) {
       const textToWrap = Array.isArray(originalText)
         ? originalText
         : originalText.split('\n');
-      let wrapped;
       if (width) {
         wrapped = textToWrap.map(tW =>
           wrapText(tW, width, canvas, originalStyle)
@@ -87,9 +86,9 @@ function Label({
       } else {
         wrapped = textToWrap.map(tW => [tW]);
       }
-      setWrappedText(wrapped);
     }
-  }, [canvas, originalStyle, originalText, width]);
+    return wrapped;
+  }, [canvas, originalText, originalStyle, width]);
   useEffect(() => {
     if (wrappedText && wrappedText.length > 1) {
       if (highlightIndex && highlightStyle) {

--- a/src/core/LegendLabel.js
+++ b/src/core/LegendLabel.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { VictoryTooltip } from 'victory';
 
+import { labels } from './utils';
 import propTypes from './propTypes';
 import Label from './Label';
 
@@ -14,7 +15,16 @@ import Label from './Label';
  */
 // while we need `width` for the label, we don't need it for tooltip
 function LegendLabel({ width, ...props }) {
-  const { colorScale, data, datum, index } = props;
+  const { colorScale, datum, index, text: textProp } = props;
+  let text = textProp;
+  if (datum) {
+    const { tooltip } = datum;
+    if (tooltip) {
+      text = tooltip;
+    } else if (datum.y) {
+      text = labels(datum);
+    }
+  }
 
   return (
     <g>
@@ -22,7 +32,7 @@ function LegendLabel({ width, ...props }) {
       <VictoryTooltip
         {...props}
         datum={{ _x: index + 1, ...datum }}
-        text={data[index].label}
+        text={text}
         labelComponent={<Label colorScale={colorScale} />}
       />
     </g>
@@ -33,21 +43,20 @@ LegendLabel.defaultEvents = VictoryTooltip.defaultEvents;
 
 LegendLabel.propTypes = {
   colorScale: propTypes.colorScale,
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string
-    })
-  ),
-  datum: PropTypes.shape({}),
+  datum: PropTypes.shape({
+    tooltip: PropTypes.string,
+    y: PropTypes.number
+  }),
   index: PropTypes.number,
+  text: PropTypes.string,
   width: PropTypes.number
 };
 
 LegendLabel.defaultProps = {
   colorScale: undefined,
-  data: undefined,
   datum: undefined,
   index: undefined,
+  text: undefined,
   width: undefined
 };
 

--- a/src/core/NestedProportionalAreaChart/ScaledCircle.js
+++ b/src/core/NestedProportionalAreaChart/ScaledCircle.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { labels } from '../utils';
 import propTypes from '../propTypes';
 import {
   DESKTOP_HEIGHT,
@@ -87,9 +88,7 @@ function ScaledCircle({
         data={radii.map(v => [v])}
         donut={false}
         height={height}
-        labels={data.map(
-          d => `${d.x}: ${d.y}\n${referenceData.x}: ${referenceData.y}`
-        )}
+        labels={data.map(d => `${labels(d)}\n${labels(referenceData)}`)}
         labelComponent={<Tooltip theme={theme} />}
         origin={{ x: cx, y: cy }}
         radii={radii}

--- a/src/core/NestedProportionalAreaChart/ScaledSquare.js
+++ b/src/core/NestedProportionalAreaChart/ScaledSquare.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Border, Selection, VictoryTooltip } from 'victory';
 
+import { labels } from '../utils';
 import propTypes from '../propTypes';
 import { MOBILE_WIDTH } from './ScaledArea';
 import VerticalLegend from './VerticalLegend';
@@ -26,13 +27,12 @@ function ScaledSquare({
     data: [referenceData],
     style: referenceStyle
   } = reference;
-  const referenceText =
-    referenceData && `${referenceData.x}: ${referenceData.y}`;
+  const referenceText = referenceData && labels(referenceData);
   const [tooltipProps, setTooltipProps] = useState({});
   const tooltip = <VictoryTooltip theme={theme} {...tooltipProps} />;
   const activateTooltip = (evt, { data: dataProp, ...otherProps }) => {
     if (dataProp) {
-      const dataText = `${dataProp.x}: ${dataProp.y}`;
+      const dataText = labels(dataProp);
       const text = referenceText ? `${dataText}\n${referenceText}` : dataText;
       const { x: tipX, y: tipY } = Selection.getSVGEventCoordinates(evt);
       setTooltipProps({ active: true, ...otherProps, text, x: tipX, y: tipY });

--- a/src/core/PieChart/DonutTooltip.js
+++ b/src/core/PieChart/DonutTooltip.js
@@ -10,37 +10,45 @@ import Tooltip from './Tooltip';
  * see: https://formidable.com/open-source/victory/guides/tooltips/#tooltips-with-other-events
  */
 function DonutTooltip({
+  center,
   cornerRadius,
   highlightIndex,
   highlightStyle,
-  center,
   width,
   x,
   y,
   ...props
 }) {
+  const { datum: originalDatum, text: originalText } = props;
+  const text = (originalDatum && originalDatum.donutLabel) || originalText;
+  const datum = { ...originalDatum, label: text };
+
   return (
     <g>
       <Tooltip
         {...props}
+        center={center}
         constrainToVisibleArea
         orientation="top"
         cornerRadius={cornerRadius}
+        datum={datum}
         flyoutHeight={width}
         flyoutStyle={{ fill: 'white', stroke: 'none' }}
         flyoutWidth={width}
         labelComponent={
           <Label
             {...props}
+            datum={datum}
             highlightIndex={highlightIndex}
             highlightStyle={highlightStyle}
             width={width}
+            text={text}
             verticalAnchor="middle"
           />
         }
         pointerLength={0}
         renderInPortal={false}
-        center={center}
+        text={text}
       />
       <Tooltip {...props} renderInPortal={false} x={x} y={y} />
     </g>
@@ -48,13 +56,15 @@ function DonutTooltip({
 }
 
 DonutTooltip.propTypes = {
-  cornerRadius: PropTypes.number,
-  highlightIndex: PropTypes.number,
-  highlightStyle: PropTypes.shape({}),
   center: PropTypes.shape({
     x: PropTypes.number,
     y: PropTypes.number
   }),
+  cornerRadius: PropTypes.number,
+  datum: PropTypes.shape({}),
+  highlightIndex: PropTypes.number,
+  highlightStyle: PropTypes.shape({}),
+  text: PropTypes.string,
   width: PropTypes.number,
   x: PropTypes.number,
   y: PropTypes.number
@@ -62,9 +72,11 @@ DonutTooltip.propTypes = {
 
 DonutTooltip.defaultProps = {
   cornerRadius: undefined,
+  datum: undefined,
   highlightIndex: undefined,
   highlightStyle: undefined,
   center: undefined,
+  text: undefined,
   width: undefined,
   x: undefined,
   y: undefined

--- a/src/core/PieChart/index.js
+++ b/src/core/PieChart/index.js
@@ -211,7 +211,7 @@ function PieChart({
               highlightStyle={chart.donutHighlightStyle}
               sortKey={donutLabelKey.sortKey}
               style={donutLabelStyle}
-              text={data1[0].label}
+              text={data1[0].donutLabel || data1[0].label}
               width={chartInnerRadius * 2}
               x={origin.x}
               y={origin.y}

--- a/src/core/ShareDropDown.js
+++ b/src/core/ShareDropDown.js
@@ -119,7 +119,7 @@ function ShareDropDown({
 }
 
 ShareDropDown.propTypes = {
-  anchorEl: PropTypes.shape({}).isRequired,
+  anchorEl: PropTypes.shape({}),
   email: PropTypes.shape({
     subject: PropTypes.string,
     body: PropTypes.string,
@@ -130,7 +130,6 @@ ShareDropDown.propTypes = {
     quote: PropTypes.string,
     hashtag: PropTypes.string
   }),
-  forwardedRef: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
   shareIcon: PropTypes.shape({
@@ -147,6 +146,7 @@ ShareDropDown.propTypes = {
 };
 
 ShareDropDown.defaultProps = {
+  anchorEl: null,
   open: undefined,
   email: null,
   facebook: null,

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -16,7 +16,10 @@ export function getLegendProps(
   // Show legend if a legend prop is provided or data contains objects with
   // `name` attribute.
   // https://formidable.com/open-source/victory/docs/victory-legend/#data
-  const legendData = legendDataProp || (data && data[0].name && data);
+  const legendData =
+    legendDataProp ||
+    (data && data[0].name && data) ||
+    data.map(d => ({ name: `${d.x || d.y}`, ...d }));
   let chartHeight = height;
   let chartWidth = width;
   let legendHeight = height;

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -16,10 +16,7 @@ export function getLegendProps(
   // Show legend if a legend prop is provided or data contains objects with
   // `name` attribute.
   // https://formidable.com/open-source/victory/docs/victory-legend/#data
-  const legendData =
-    legendDataProp ||
-    (data && data[0].name && data) ||
-    data.map(d => ({ name: `${d.x || d.y}`, ...d }));
+  const legendData = legendDataProp || (data && data[0].name && data);
   let chartHeight = height;
   let chartWidth = width;
   let legendHeight = height;

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -131,3 +131,11 @@ export function domToPng(node, { style: nodeStyle, ...options }) {
   }
   return Promise.resolve(undefined);
 }
+
+/**
+ * Default `labels` function for HURUmap UI
+ */
+export const labels = ({ x, y, unit = '' }) => {
+  const formatedX = x ? `${x}: ` : '';
+  return `${formatedX}${y}${unit}`;
+};

--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -103,7 +103,7 @@ function ChartFactory({
       }
       return `${numberFormatter.format(
         formatValue
-      )}${compactUnit} ${customUnit}`;
+      )}${compactUnit} ${customUnit}`.trim(); // in case customUnit is empty
     },
     [customUnit, numberFormat.style, numberFormatter]
   );

--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -109,17 +109,24 @@ function ChartFactory({
   );
 
   const primaryData = useMemo(() => {
+    const tooltip = ({ x, y }) => {
+      const formatedX = x ? `${x}: ` : '';
+      return `${formatedX}${format(y)}`;
+    };
     if (visualType === 'column') {
       const computedData = aggregateData(aggregate, data);
       setDataLength(computedData.length);
-      return computedData.slice(show);
+      return computedData.slice(show).map(cD => ({
+        ...cD,
+        tooltip: tooltip(cD)
+      }));
     }
 
     if (visualType === 'pie') {
       return aggregateData(aggregate, data).map(d => ({
         ...d,
         name: d.x,
-        label: `${d.x} ${format(d.y)}`
+        label: tooltip(d)
       }));
     }
 
@@ -139,7 +146,7 @@ function ChartFactory({
     groupedData = groupedData.map(g =>
       g.map(gd => ({
         ...gd,
-        tooltip: `${gd.x}: ${format(gd.y)}`,
+        tooltip: tooltip(gd),
         x: gd.groupBy
       }))
     );
@@ -309,7 +316,7 @@ function ChartFactory({
               height={computedHeight}
               horizontal={computedHorizontal}
               domainPadding={domainPadding}
-              labels={({ datum }) => formatLabelValue(datum.y)}
+              labels={({ datum }) => format(datum.y)}
               theme={theme}
               {...chartProps}
             />

--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -109,8 +109,8 @@ function ChartFactory({
   );
 
   const primaryData = useMemo(() => {
-    const tooltip = ({ x, y }) => {
-      const formatedX = x ? `${x}: ` : '';
+    const labels = ({ x, y }, separator = ': ') => {
+      const formatedX = x ? `${x}${separator}` : '';
       return `${formatedX}${format(y)}`;
     };
     if (visualType === 'column') {
@@ -118,7 +118,7 @@ function ChartFactory({
       setDataLength(computedData.length);
       return computedData.slice(show).map(cD => ({
         ...cD,
-        tooltip: tooltip(cD)
+        tooltip: labels(cD)
       }));
     }
 
@@ -126,7 +126,8 @@ function ChartFactory({
       return aggregateData(aggregate, data).map(d => ({
         ...d,
         name: d.x,
-        label: tooltip(d)
+        donutLabel: labels(d, '\n'),
+        label: labels(d)
       }));
     }
 
@@ -146,7 +147,7 @@ function ChartFactory({
     groupedData = groupedData.map(g =>
       g.map(gd => ({
         ...gd,
-        tooltip: tooltip(gd),
+        tooltip: labels(gd),
         x: gd.groupBy
       }))
     );

--- a/src/factory/utils/aggregateData.js
+++ b/src/factory/utils/aggregateData.js
@@ -36,7 +36,10 @@ function aggregate(option, data, unique = true) {
   if (unique) {
     const uniqueX = [...new Set(data.map(d => d.x))];
     uniqueX.forEach(x => {
-      const computedData = computeData(func, data.filter(d => d.x === x));
+      const computedData = computeData(
+        func,
+        data.filter(d => d.x === x)
+      );
       reduced[x] = {
         ...computedData,
         x: selectFunc[func] ? computedData.x : x,

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -39,7 +39,6 @@ storiesOf('HURUmap UI|Charts/BarChart', module)
             const y = rand();
             const x = `${index}-${index} Employment Status`;
             return {
-              tooltip: `${x}: ${y}`,
               x,
               y
             };
@@ -126,12 +125,11 @@ storiesOf('HURUmap UI|Charts/Bullet Chart', module)
     <div>
       <BulletChart
         data={object('data', [
-          { x: 49, label: 'Male' },
-          { x: 51, label: 'Female' }
+          { x: 'Male', y: 49, unit: '%' },
+          { x: 'Female', y: 51, unit: '%' }
         ])}
         height={number('height', 100)}
-        labels={d => (d.label && `${d.label}: ${d.x}%`) || ''}
-        reference={object('reference', [{ x: 51, label: '' }])}
+        reference={object('reference', [{ x: 51 }])}
         total={100}
         width={number('width', 350)}
       />
@@ -146,11 +144,10 @@ storiesOf('HURUmap UI|Charts/Bullet Chart', module)
           // Below data is equivalent to:
           // [{ x: 12.7, label: 'Living in urban areas' }, { x: 100 }],
           // [{ x: 9.3, label: 'Living in rural areas' }, { x: 100 }]
-          [{ x: 12.7, label: 'Living in urban areas' }],
-          [{ x: 9.3, label: 'Living in rural areas' }]
+          [{ x: 'Living in urban areas', y: 12.7, unit: '%' }],
+          [{ x: 'Living in rural areas', y: 9.3, unit: '%' }]
         ])}
-        reference={object('reference', [{ x: 51, label: '' }])}
-        labels={d => (d.label && `${d.label}: ${d.x}%`) || ''}
+        reference={object('reference', [{ y: 51 }])}
         total={100}
         width={number('width', 350)}
       />
@@ -256,7 +253,10 @@ storiesOf('HURUmap UI|Charts/LineChart', module)
             ],
             x: number('Legend x', 90)
           },
-          scatter: [{ size: 5, symbol: 'circle' }, { size: 5, symbol: 'plus' }],
+          scatter: [
+            { size: 5, symbol: 'circle' },
+            { size: 5, symbol: 'plus' }
+          ],
           tooltip: { style: { textAnchor: 'start' } }
         }}
       />

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -233,23 +233,23 @@ storiesOf('HURUmap UI|Charts/LineChart', module)
             data: [
               {
                 name: 'A',
-                label: 'A\n \nDar es Salaam 6\n \nKagera 3'
+                tooltip: 'A\n \nDar es Salaam 6\n \nKagera 3'
               },
               {
                 name: 'B',
-                label: 'B\n \nDar es Salaam 1\n \nKagera 1'
+                tooltip: 'B\n \nDar es Salaam 1\n \nKagera 1'
               },
               {
                 name: 'C',
-                label: 'C\n \nDar es Salaam 3\n \nKagera 2'
+                tooltip: 'C\n \nDar es Salaam 3\n \nKagera 2'
               },
               {
                 name: 'D',
-                label: 'D\n \nDar es Salaam 1\n \nKagera 2'
+                tooltip: 'D\n \nDar es Salaam 1\n \nKagera 2'
               },
               {
                 name: 'E',
-                label: 'E\n \nDar es Salaam 12\n \nKagera 5'
+                tooltip: 'E\n \nDar es Salaam 12\n \nKagera 5'
               }
             ],
             x: number('Legend x', 90)
@@ -275,8 +275,20 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
       <div style={{ height, width }}>
         <PieChart
           data={object('data', [
-            { x: 'Female', y: 22, donutLabel: 'Female\n22%', unit: '%' },
-            { x: 'Male', y: 78, donutLabel: 'Male\n78%', unit: '%' }
+            {
+              x: 'Female',
+              y: 22,
+              donutLabel: 'Female\n22%',
+              name: 'Female',
+              unit: '%'
+            },
+            {
+              x: 'Male',
+              y: 78,
+              donutLabel: 'Male\n78%',
+              name: 'Male',
+              unit: '%'
+            }
           ])}
           donut={boolean('donut', true)}
           donutLabelKey={object('donutLabelKey', { dataIndex: 0 })}

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -8,6 +8,7 @@ import {
   number
 } from '@storybook/addon-knobs';
 
+import { labels } from '../src/core/utils';
 import {
   BarChart,
   BulletChart,
@@ -273,24 +274,25 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
     return (
       <div style={{ height, width }}>
         <PieChart
+          data={object('data', [
+            { x: 'Female', y: 22, donutLabel: 'Female\n22%', unit: '%' },
+            { x: 'Male', y: 78, donutLabel: 'Male\n78%', unit: '%' }
+          ])}
           donut={boolean('donut', true)}
           donutLabelKey={object('donutLabelKey', { dataIndex: 0 })}
-          data={object('data', [
-            { x: 'Female', y: 22, label: 'Female\n22%' },
-            { x: 'Male', y: 78, label: 'Male\n78%' }
-          ])}
-          width={width}
           height={height}
+          labels={({ datum }) => labels(datum)}
+          legendWidth={legendWidth}
           parts={{
             legend: {
               data: [
                 {
                   name: 'Female',
-                  label: 'Female\n22%'
+                  label: 'Female: 22%'
                 },
                 {
                   name: 'Male',
-                  label: 'Male\n78%'
+                  label: 'Male: 78%'
                 }
               ],
               rowGutter: number('Legend row spacing', 20),
@@ -299,9 +301,9 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
               }
             }
           }}
-          legendWidth={legendWidth}
           responsive={boolean('responsive', true)}
           standalone={boolean('standalone', true)}
+          width={width}
         />
       </div>
     );

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -285,16 +285,6 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
           legendWidth={legendWidth}
           parts={{
             legend: {
-              data: [
-                {
-                  name: 'Female',
-                  label: 'Female: 22%'
-                },
-                {
-                  name: 'Male',
-                  label: 'Male: 78%'
-                }
-              ],
               rowGutter: number('Legend row spacing', 20),
               style: {
                 labels: object('Legend style', undefined)
@@ -320,14 +310,14 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
               {
                 x: 'A',
                 y: 6,
-                donutLabel: 'A\nDar es Salaam 1',
-                label: 'A: Dar es Salaam 1'
+                donutLabel: 'A\nDar es Salaam 6',
+                label: 'A: Dar es Salaam 6'
               },
               {
                 x: 'B',
                 y: 1,
-                donutLabel: 'B\nDar es Salaam 2',
-                label: 'B: Dar es Salaam 2'
+                donutLabel: 'B\nDar es Salaam 1',
+                label: 'B: Dar es Salaam 1'
               },
               {
                 x: 'C',
@@ -344,15 +334,15 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
               {
                 x: 'E',
                 y: 12,
-                donutLabel: 'E\nDar es Salaam 2',
-                label: 'E: Dar es Salaam 2'
+                donutLabel: 'E\nDar es Salaam 12',
+                label: 'E: Dar es Salaam 12'
               }
             ],
             [
-              { x: 'A', y: 3, donutLabel: 'A\nKagera 2', label: 'A: Kagera 2' },
+              { x: 'A', y: 3, donutLabel: 'A\nKagera 3', label: 'A: Kagera 3' },
               { x: 'B', y: 1, donutLabel: 'B\nKagera 1', label: 'B: Kagera 1' },
-              { x: 'C', y: 2, donutLabel: 'C\nKagera 1', label: 'C: Kagera 1' },
-              { x: 'D', y: 2, donutLabel: 'D\nKagera 1', label: 'D: Kagera 1' },
+              { x: 'C', y: 2, donutLabel: 'C\nKagera 2', label: 'C: Kagera 2' },
+              { x: 'D', y: 2, donutLabel: 'D\nKagera 2', label: 'D: Kagera 2' },
               { x: 'E', y: 5, donutLabel: 'E\nKagera 5', label: 'E: Kagera 5' }
             ]
           ])}
@@ -370,23 +360,23 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
               data: object('Legend data', [
                 {
                   name: 'A',
-                  label: 'Dar es Salaam: 1\nKagera: 2'
+                  tooltip: 'Dar es Salaam: 6\nKagera: 3'
                 },
                 {
                   name: 'B',
-                  label: 'Dar es Salaam: 2\nKagera: 1'
+                  tooltip: 'Dar es Salaam: 1\nKagera: 1'
                 },
                 {
                   name: 'C',
-                  label: 'Dar es Salaam: 3\nKagera: 1'
+                  tooltip: 'Dar es Salaam: 3\nKagera: 2'
                 },
                 {
                   name: 'D',
-                  label: 'Dar es Salaam: 1\nKagera: 1'
+                  tooltip: 'Dar es Salaam: 1\nKagera: 2'
                 },
                 {
                   name: 'E',
-                  label: 'Dar es Salaam: 2\nKagera: 5'
+                  tooltip: 'Dar es Salaam: 12\nKagera: 5'
                 }
               ]),
               gutter: number('Legend column spacing', 10),

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -315,18 +315,43 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
         <PieChart
           data={object('data', [
             [
-              { x: 'A', y: 6, label: 'A\nDar es Salaam 1' },
-              { x: 'B', y: 1, label: 'B\nDar es Salaam 2' },
-              { x: 'C', y: 3, label: 'C\nDar es Salaam 3' },
-              { x: 'D', y: 1, label: 'D\nDar es Salaam 1' },
-              { x: 'E', y: 12, label: 'E\nDar es Salaam 2' }
+              {
+                x: 'A',
+                y: 6,
+                donutLabel: 'A\nDar es Salaam 1',
+                label: 'A: Dar es Salaam 1'
+              },
+              {
+                x: 'B',
+                y: 1,
+                donutLabel: 'B\nDar es Salaam 2',
+                label: 'B: Dar es Salaam 2'
+              },
+              {
+                x: 'C',
+                y: 3,
+                donutLabel: 'C\nDar es Salaam 3',
+                label: 'C: Dar es Salaam 3'
+              },
+              {
+                x: 'D',
+                y: 1,
+                donutLabel: 'D\nDar es Salaam 1',
+                label: 'D: Dar es Salaam 1'
+              },
+              {
+                x: 'E',
+                y: 12,
+                donutLabel: 'E\nDar es Salaam 2',
+                label: 'E: Dar es Salaam 2'
+              }
             ],
             [
-              { x: 'A', y: 3, label: 'A\nKagera 2' },
-              { x: 'B', y: 1, label: 'B\nKagera 1' },
-              { x: 'C', y: 2, label: 'C\nKagera 1' },
-              { x: 'D', y: 2, label: 'D\nKagera 1' },
-              { x: 'E', y: 5, label: 'E\nKagera 5' }
+              { x: 'A', y: 3, donutLabel: 'A\nKagera 2', label: 'A: Kagera 2' },
+              { x: 'B', y: 1, donutLabel: 'B\nKagera 1', label: 'B: Kagera 1' },
+              { x: 'C', y: 2, donutLabel: 'C\nKagera 1', label: 'C: Kagera 1' },
+              { x: 'D', y: 2, donutLabel: 'D\nKagera 1', label: 'D: Kagera 1' },
+              { x: 'E', y: 5, donutLabel: 'E\nKagera 5', label: 'E: Kagera 5' }
             ]
           ])}
           donut={boolean('donut', true)}

--- a/stories/container.stories.js
+++ b/stories/container.stories.js
@@ -172,8 +172,12 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
       }
       CustomPopover.propTypes = {
         open: PropTypes.bool.isRequired,
-        anchorEl: PropTypes.shape.isRequired,
+        anchorEl: PropTypes.shape({}),
         onClose: PropTypes.func.isRequired
+      };
+
+      CustomPopover.defaultProps = {
+        anchorEl: null
       };
 
       const share = boolean('Share', true);

--- a/stories/factory.stories.js
+++ b/stories/factory.stories.js
@@ -46,9 +46,11 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
         }}
         data={data.map((_, index) => {
           const y = rand();
+          const x = `${index} Dummy Data`;
           return {
+            name: type === 'pie' ? x : undefined,
             tooltip: `${index} Dummy Data`,
-            x: `${index} Dummy Data`,
+            x,
             y
           };
         })}

--- a/stories/mapit.stories.js
+++ b/stories/mapit.stories.js
@@ -23,7 +23,10 @@ storiesOf('HURUmap UI|MapIt/Geography', module)
       tolerance={number('tolerance', 0.01)}
       url={text('url', 'https://mapit.hurumap.org')}
       drawChildren={boolean('drawChildren', true)}
-      filterCountries={array('filterCountries', countries.map(c => c.iso_code))}
+      filterCountries={array(
+        'filterCountries',
+        countries.map(c => c.iso_code)
+      )}
       drawProfile={boolean('drawProfile', false)}
       codeType={text('codeType', 'AFR')}
       geoLevel={text('geoLevel', 'continent')}


### PR DESCRIPTION
## Description

- [x] All charts should have a `x: y` tooltips, e.g. `2019: 10000`,
- [x] `PieChart` adds `donutLabel` prop to hold  a custom label for the donut: e.g.
    `2019\n10000` (Optional, if not provided, the `label` above will be used),
- [x] `Legend` data should use `tooltip` instead of `label` prop on data for legend tooltip; `label` is used by Victory for styling,
- [x] `ChartFactory` should respect the above, and
- [x] Ensure _all_ charts use `y` for data/numeric value

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Peek 2019-12-04 09-57](https://user-images.githubusercontent.com/1779590/70119999-8f0d7100-167c-11ea-8284-e0e577fcab18.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation