### PR TITLE
Fix iframe downloads

### DIFF
--- a/src/core/InsightContainer/index.js
+++ b/src/core/InsightContainer/index.js
@@ -141,7 +141,11 @@ function InsightContainer({
   const downloadHiddenClassName = 'Download--hidden';
   const toPng = () => {
     const filter = n => {
-      const { classList } = n;
+      const { classList, tagName } = n;
+      if (tagName === 'SCRIPT') {
+        return false;
+      }
+
       if (!classList) {
         return true;
       }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -112,7 +112,9 @@ export function domToPng(node, { style: nodeStyle, ...options }) {
       const iframe = iframes[0];
       if (iframe.contentWindow && iframe.contentWindow.domtoimage) {
         return iframe.contentWindow.domtoimage
-          .toPng(iframe.contentDocument.body)
+          .toPng(iframe.contentDocument.body, {
+            ...options
+          })
           .then(dataUrl => {
             const img = new Image();
             img.src = dataUrl;

--- a/stories/container.stories.js
+++ b/stories/container.stories.js
@@ -456,6 +456,13 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
       const containerWidth = 950;
       const variant = 'data';
 
+      const iframeSrc = text('iframeSrc', '/public/iframe.html');
+
+      const documentDomain = text('documentDomain');
+      if (documentDomain) {
+        document.domain = documentDomain;
+      }
+
       return (
         <div style={{ width: containerWidth }}>
           <InsightContainer
@@ -494,7 +501,7 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
           >
             <div />
             <iframe
-              src="/public/iframe.html"
+              src={iframeSrc || `/public/iframe.html`}
               title="Title"
               width="100%"
               height="100%"


### PR DESCRIPTION
## Description

Ignore the script elements for dom to image since they sometimes cause errors. Dom to image does not need scripts so it is safe to ignore.

Test setting:

```
iframeSrc: http://localhost:8080/wp-json/hurumap-data/flourish/RqiI1akD/
documentDomain: localhost
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation