### PR TITLE
[Hotfix] Nested Area Data Label

### DIFF
--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -204,17 +204,17 @@ function ChartFactory({
                   ? [
                       {
                         y: summedData,
-                        label: dataLabel
+                        x: dataLabel
                       }
                     ]
                   : [
                       {
                         y: summedData,
-                        label: dataLabel
+                        x: dataLabel
                       },
                       {
                         y: comparisonData.reduce((a, b) => a + b.y, 0),
-                        label:
+                        x:
                           comparisonData[0].label ||
                           profiles.comparison[label] ||
                           label


### PR DESCRIPTION
## Description

Use `x` for data point label; not `label`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation