### PR TITLE
[Hotfix] Prioritise profile label for Nested Area Chart labels

### DIFF
--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -176,21 +176,24 @@ function ChartFactory({
     switch (visualType) {
       case 'square_nested_proportional_area':
       case 'circle_nested_proportional_area': {
-        const dataLabel = data[0].x || data[0].label || profiles.profile[label];
         const summedData = aggregateData('sum', data, false)[0].y;
         let summedReferenceData = referenceData.reduce((a, b) => a + b.y, 0);
-        const referenceLabel =
-          (referenceData.length && summedReferenceData
-            ? referenceData[0].x || referenceData[0].label
-            : dataLabel) ||
-          // Default reference label is the chart label
-          profiles.parent[propReferenceLabel || label] ||
-          propReferenceLabel ||
-          label;
         summedReferenceData =
           referenceData.length && summedReferenceData
             ? summedReferenceData
             : summedData;
+        const dataLabel =
+          (label && profiles.profile[label]) ||
+          data[0].x ||
+          data[0].label ||
+          label;
+        const referenceLabelProp = propReferenceLabel || label;
+        const referenceLabel =
+          (referenceLabelProp && profiles.parent[referenceLabelProp]) ||
+          (referenceData.length && summedReferenceData
+            ? referenceData[0].x || referenceData[0].label
+            : dataLabel) ||
+          referenceLabelProp;
 
         return (
           <div style={{ width: !isComparison ? 200 : 650 }}>


### PR DESCRIPTION
## Description

Prioritize profile `label` for `NestedProportionalAreaChart` labels.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation