### PR TITLE
[Hotfix] chart `id` in ChartFactory

### DIFF
--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -401,7 +401,7 @@ function ChartFactory({
   };
 
   return (
-    <Box display="flex" flexDirection="column">
+    <Box display="flex" flexDirection="column" id={id}>
       {renderChart()}
       {toggleSize &&
         ['column', 'grouped_column'].includes(visualType) &&

--- a/stories/factory.stories.js
+++ b/stories/factory.stories.js
@@ -38,6 +38,7 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
     return (
       <ChartFactory
         definition={{
+          id: 'data-indicator-10',
           type,
           typeProps: {
             horizontal


### PR DESCRIPTION
## Description

If  `id` is provided as part of chart definition, ChartFactory should include it in the final `div`. This will help us link to a given chart directly from search results, social media sharing, etc.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/71877013-362c6f00-3139-11ea-9fa6-6b15cd6497b3.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation