### PR TITLE
[Hotfix] Theme proptypes on chartfactory

### DIFF
--- a/src/factory/ChartFactory.js
+++ b/src/factory/ChartFactory.js
@@ -418,7 +418,7 @@ function ChartFactory({
 }
 
 ChartFactory.propTypes = {
-  theme: propTypes.theme.isRequired,
+  theme: propTypes.shape({}).isRequired,
   definition: propTypes.shape({
     id: propTypes.string,
     type: propTypes.string,


### PR DESCRIPTION
## Description
Theme props on chartfactory has a wrong proptypes.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation