### PR TITLE
ChartContainer variant support

### DIFF
--- a/src/core/ChartContainer.js
+++ b/src/core/ChartContainer.js
@@ -46,8 +46,12 @@ const useStyles = makeStyles(({ palette }) => ({
     height: '2.5rem',
     width: '2.5rem'
   },
-  title: {},
-  subtitle: {},
+  title: props => ({
+    textAlign: props.variant === 'analysis' ? 'center' : 'inherit'
+  }),
+  subtitle: props => ({
+    textAlign: props.variant === 'analysis' ? 'center' : 'inherit'
+  }),
   source: {
     width: '100%'
   },
@@ -113,6 +117,7 @@ function ChartContainer({
   ...props
 }) {
   const classes = useStyles(props);
+  const { variant } = props;
   const getReferenceObject = ref => {
     const { current } = ref;
     if (current) {
@@ -244,132 +249,151 @@ function ChartContainer({
       }));
   const logo = logoProp || defaultLogo;
 
+  const titleComponents = (
+    <>
+      <TypographyLoader
+        loading={loading}
+        loader={{
+          primaryOpacity: 0.5,
+          secondaryOpacity: 1
+        }}
+        className={classes.title}
+        variant="body1"
+      >
+        {title}
+      </TypographyLoader>
+      {subtitle && subtitle.length > 0 && (
+        <TypographyLoader
+          loading={loading}
+          loader={{
+            primaryOpacity: 0.5,
+            secondaryOpacity: 1
+          }}
+          className={classes.subtitle}
+          variant="caption"
+        >
+          {subtitle}
+        </TypographyLoader>
+      )}
+    </>
+  );
+  const actionComponents = (
+    <>
+      {onClickShare && (
+        <BlockLoader loading={loading} width={40} height={40}>
+          <ButtonBase
+            className={classes.actionButton}
+            onClick={() => onClickShare(getReferenceObject(shareButtonRef))}
+            ref={shareButtonRef}
+          >
+            <ShareIcon />
+          </ButtonBase>
+        </BlockLoader>
+      )}
+
+      {onClickEmbed && (
+        <BlockLoader loading={loading} width={40} height={40}>
+          <ButtonBase
+            className={classes.actionButton}
+            onClick={() => onClickEmbed(getReferenceObject(embedButtonRef))}
+            ref={embedButtonRef}
+          >
+            <EmbedIcon />
+          </ButtonBase>
+        </BlockLoader>
+      )}
+
+      {onClickDownload && (
+        <BlockLoader loading={loading} width={40} height={40}>
+          <ButtonBase
+            className={classes.actionButton}
+            onClick={() =>
+              toPng().then(
+                onClickDownload.bind(
+                  null,
+                  getReferenceObject(downloadButtonRef)
+                )
+              )
+            }
+            ref={downloadButtonRef}
+          >
+            <DownloadIcon />
+          </ButtonBase>
+        </BlockLoader>
+      )}
+
+      {onClickCompare && (
+        <BlockLoader loading={loading} width={40} height={40}>
+          <ButtonBase
+            className={classes.actionButton}
+            onClick={() => onClickCompare(getReferenceObject(compareButtonRef))}
+            ref={compareButtonRef}
+          >
+            <CompareIcon />
+          </ButtonBase>
+        </BlockLoader>
+      )}
+
+      {onClickData && (
+        <BlockLoader loading={loading} width={40} height={40}>
+          <ButtonBase
+            className={classes.actionButton}
+            onClick={() => onClickData(getReferenceObject(dataButtonRef))}
+            ref={dataButtonRef}
+          >
+            <DataIcon />
+          </ButtonBase>
+        </BlockLoader>
+      )}
+
+      {embedDropDown}
+      {shareDropDown}
+    </>
+  );
   return (
     <div ref={chartRef} className={classes.root}>
       <Grid container className={classes.containerRoot}>
         <Grid item xs={12} container className={classes.chart}>
-          <Grid
-            item
-            xs={12}
-            container
-            wrap="nowrap"
-            direction="row"
-            alignItems="flex-start"
-            justify="space-between"
-          >
-            <Grid item xs={8}>
-              <TypographyLoader
-                loading={loading}
-                loader={{
-                  primaryOpacity: 0.5,
-                  secondaryOpacity: 1
-                }}
-                className={classes.title}
-                variant="body1"
-              >
-                {title}
-              </TypographyLoader>
-              <TypographyLoader
-                loading={loading}
-                loader={{
-                  primaryOpacity: 0.5,
-                  secondaryOpacity: 1
-                }}
-                className={classes.subtitle}
-                variant="caption"
-              >
-                {subtitle}
-              </TypographyLoader>
-            </Grid>
-
+          {variant === 'data' && (
             <Grid
               item
-              xs={4}
+              xs={12}
               container
               wrap="nowrap"
               direction="row"
-              justify="flex-end"
-              className={`${downloadHiddenClassName} ${classes.actions}`}
+              alignItems="flex-start"
+              justify="space-between"
             >
-              {onClickShare && (
-                <BlockLoader loading={loading} width={40} height={40}>
-                  <ButtonBase
-                    className={classes.actionButton}
-                    onClick={() =>
-                      onClickShare(getReferenceObject(shareButtonRef))
-                    }
-                    ref={shareButtonRef}
-                  >
-                    <ShareIcon />
-                  </ButtonBase>
-                </BlockLoader>
-              )}
+              <Grid item xs={8}>
+                {titleComponents}
+              </Grid>
 
-              {onClickEmbed && (
-                <BlockLoader loading={loading} width={40} height={40}>
-                  <ButtonBase
-                    className={classes.actionButton}
-                    onClick={() =>
-                      onClickEmbed(getReferenceObject(embedButtonRef))
-                    }
-                    ref={embedButtonRef}
-                  >
-                    <EmbedIcon />
-                  </ButtonBase>
-                </BlockLoader>
-              )}
-
-              {onClickDownload && (
-                <BlockLoader loading={loading} width={40} height={40}>
-                  <ButtonBase
-                    className={classes.actionButton}
-                    onClick={() =>
-                      toPng().then(
-                        onClickDownload.bind(
-                          null,
-                          getReferenceObject(downloadButtonRef)
-                        )
-                      )
-                    }
-                    ref={downloadButtonRef}
-                  >
-                    <DownloadIcon />
-                  </ButtonBase>
-                </BlockLoader>
-              )}
-
-              {onClickCompare && (
-                <BlockLoader loading={loading} width={40} height={40}>
-                  <ButtonBase
-                    className={classes.actionButton}
-                    onClick={() =>
-                      onClickCompare(getReferenceObject(compareButtonRef))
-                    }
-                    ref={compareButtonRef}
-                  >
-                    <CompareIcon />
-                  </ButtonBase>
-                </BlockLoader>
-              )}
-
-              {onClickData && (
-                <BlockLoader loading={loading} width={40} height={40}>
-                  <ButtonBase
-                    className={classes.actionButton}
-                    onClick={() =>
-                      onClickData(getReferenceObject(dataButtonRef))
-                    }
-                    ref={dataButtonRef}
-                  >
-                    <DataIcon />
-                  </ButtonBase>
-                </BlockLoader>
-              )}
-
-              {embedDropDown}
-              {shareDropDown}
+              <Grid
+                item
+                xs={4}
+                container
+                wrap="nowrap"
+                direction="row"
+                justify="flex-end"
+                className={`${downloadHiddenClassName} ${classes.actions}`}
+              >
+                {actionComponents}
+              </Grid>
             </Grid>
-          </Grid>
+          )}
+          {variant === 'analysis' && (
+            <Grid
+              item
+              xs={12}
+              container
+              wrap="nowrap"
+              direction="row"
+              alignItems="center"
+              justify="center"
+            >
+              <Grid item>{titleComponents}</Grid>
+            </Grid>
+          )}
           <Grid
             item
             xs={12}
@@ -395,13 +419,31 @@ function ChartContainer({
                 className={`${downloadHiddenClassName} ${classes.source}`}
               >
                 {sourceLink && (
-                  <A className={classes.sourceLink} href={sourceLink}>
+                  <A
+                    variant="caption"
+                    className={classes.sourceLink}
+                    href={sourceLink}
+                  >
                     {`Source: ${sourceTitle || sourceLink}`}
                   </A>
                 )}
               </TypographyLoader>
             </div>
           </Grid>
+          {variant === 'analysis' && (
+            <Grid
+              item
+              xs={12}
+              container
+              wrap="nowrap"
+              direction="row"
+              alignItems="center"
+              justify="center"
+              className={downloadHiddenClassName}
+            >
+              <Grid item>{actionComponents}</Grid>
+            </Grid>
+          )}
         </Grid>
       </Grid>
       {description && (
@@ -411,9 +453,11 @@ function ChartContainer({
           wrap="nowrap"
           className={classes.descriptionWrapper}
         >
-          <Typography variant="caption" className={classes.description}>
-            {description}
-          </Typography>
+          <Grid item>
+            <Typography variant="caption" className={classes.description}>
+              {description}
+            </Typography>
+          </Grid>
         </Grid>
       )}
       <Grid
@@ -437,15 +481,21 @@ function ChartContainer({
 }
 
 ChartContainer.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired,
+  content: PropTypes.shape({
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  }),
+  description: PropTypes.string,
   embed: PropTypes.shape({
     title: PropTypes.string.isRequired,
     subtitle: PropTypes.string,
     code: PropTypes.string
   }),
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
-  ]).isRequired,
+  loading: PropTypes.bool,
   logo: PropTypes.string,
   onClickCompare: PropTypes.func,
   onClickData: PropTypes.func,
@@ -473,16 +523,11 @@ ChartContainer.propTypes = {
       hashtags: PropTypes.string
     })
   }),
-  subtitle: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string,
   sourceLink: PropTypes.string,
   sourceTitle: PropTypes.string,
-  loading: PropTypes.bool,
-  content: PropTypes.shape({
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-  })
+  subtitle: PropTypes.string,
+  title: PropTypes.string.isRequired,
+  variant: PropTypes.oneOf(['data', 'analysis'])
 };
 
 ChartContainer.defaultProps = {
@@ -519,7 +564,9 @@ style="margin: 1em; max-width: 18.75rem;"
   content: {
     width: '100%',
     height: '100%'
-  }
+  },
+  subtitle: undefined,
+  variant: 'data'
 };
 
 export default ChartContainer;

--- a/src/core/ChartContainer.js
+++ b/src/core/ChartContainer.js
@@ -19,7 +19,7 @@ import DownloadIcon from './assets/icons/download.svg';
 import EmbedIcon from './assets/icons/code.svg';
 import ShareIcon from './assets/icons/network-connection.svg';
 
-const useStyles = makeStyles(({ palette }) => ({
+const useStyles = makeStyles(({ breakpoints, palette }) => ({
   root: {
     backgroundColor: '#f1f1ed'
   },
@@ -94,7 +94,12 @@ const useStyles = makeStyles(({ palette }) => ({
   descriptionWrapper: {
     marginTop: '1.75rem'
   },
-  description: {}
+  description: {
+    [breakpoints.up('md')]: {
+      display: 'block',
+      width: '62.36%' // golden-ratio
+    }
+  }
 }));
 
 function ChartContainer({

--- a/src/core/EmbedDropDown.js
+++ b/src/core/EmbedDropDown.js
@@ -42,6 +42,7 @@ function EmbedDropDown({
       onClose={onClose}
       open={open}
       classes={{ root: classes.dropDownRoot, paper: classes.dropDownPaper }}
+      {...props}
     >
       <Container className={classes.root}>
         {title && <DialogTitle className={classes.title}>{title}</DialogTitle>}

--- a/src/core/ShareDropDown.js
+++ b/src/core/ShareDropDown.js
@@ -62,8 +62,9 @@ function ShareDropDown({
       onClose={onClose}
       open={open}
       classes={{ root: classes.dropDownRoot, paper: classes.dropDownPaper }}
+      {...props}
     >
-      <Grid className={classes.root} container justify="center" {...props}>
+      <Grid className={classes.root} container justify="center">
         {title && <DialogTitle className={classes.title}>{title}</DialogTitle>}
         <DialogContent>
           <Grid
@@ -147,9 +148,9 @@ ShareDropDown.propTypes = {
 
 ShareDropDown.defaultProps = {
   anchorEl: null,
-  open: undefined,
   email: null,
   facebook: null,
+  open: undefined,
   shareIcon: {
     round: false,
     size: 40

--- a/stories/container.stories.js
+++ b/stories/container.stories.js
@@ -33,6 +33,8 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
   .addDecorator(withKnobs)
   .add('Default', () =>
     React.createElement(() => {
+      const loading = boolean('loading', true);
+      const variant = select('variant', ['data', 'analysis'], 'data');
       const chartType = select('chartType', ['bar', 'pie'], 'pie');
       const classes = makeStyles(({ breakpoints }) => ({
         title: {
@@ -68,7 +70,7 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
             )}
           >
             <ChartContainer
-              loading={boolean('loading', true)}
+              loading={loading}
               title={text('title', 'Lorem ipsum dolor sit amet.')}
               subtitle={text(
                 'Subtitle',
@@ -80,7 +82,7 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
               })}
               sourceTitle={text(
                 'sourceTitle',
-                'Census 2011: Statistics South Africa (2011) South African Population Census 2011. Indicators derived from the full population Census'
+                'Census 2011: Statistics South Africa (2011) South African Population Census 2011'
               )}
               sourceLink="http://dev.dominion.africa"
               content={object('content', { height: 400, width: '100%' })}
@@ -92,6 +94,7 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
                 title: classes.title,
                 embedDropDownRoot: classes.embedModal
               }}
+              variant={variant}
             >
               {chartType === 'pie' && (
                 <div style={{ height: 350, width: 350 }}>
@@ -122,13 +125,13 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
               )}
 
               {chartType === 'bar' && (
-                <div style={{ width: 500, height: 300 }}>
+                <div style={{ width: 350, height: 350 }}>
                   <BarChart
                     horizontal={boolean('horizontal', false)}
-                    width={500}
-                    height={300}
+                    width={350}
+                    height={350}
                     domainPadding={object('domainPadding', { x: 15 })}
-                    data={Array(number('data', 10))
+                    data={Array(number('data', 5))
                       .fill(null)
                       .map((_, index) => ({
                         x: `${index} wrap label`,
@@ -180,6 +183,8 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
         anchorEl: null
       };
 
+      const loading = boolean('loading', true);
+      const variant = select('variant', ['data', 'analysis'], 'data');
       const share = boolean('Share', true);
       const download = boolean('Download', true);
       const embed = boolean('Embed', true);
@@ -190,7 +195,7 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
           container
           justify="center"
           alignItems="center"
-          style={{ background: 'whitesmoke', height: '100%' }}
+          style={{ background: 'whitesmoke', height: '50rem' }}
         >
           <Grid
             item
@@ -206,10 +211,8 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
             )}
           >
             <ChartContainer
-              content={{
-                height: 338
-              }}
-              loading={boolean('loading', false)}
+              content={object('content', { height: 400, width: '100%' })}
+              loading={loading}
               onClickShare={
                 share ? anchorEl => onClick(anchorEl, 'Share') : null
               }
@@ -228,27 +231,30 @@ storiesOf('HURUmap UI|ChartContainers/ChartContainer', module)
                 'Subtitle',
                 'Praesent at dignissim est. Integer porta consectetur ante, ut congue erat.'
               )}
+              variant={variant}
             >
-              <BarChart
-                horizontal={boolean('horizontal', false)}
-                width={500}
-                height={300}
-                data={Array(number('data', 10))
-                  .fill(null)
-                  .map((_, index) => ({
-                    x: `${index}-${index}`,
-                    y: rand()
-                  }))}
-                domainPadding={{ x: 40 }}
-                parts={{
-                  axis: {
-                    dependent: {
-                      tickValues: [10, 50, 90],
-                      tickFormat: ['10%', '50%', '90%']
+              <div style={{ width: 350, height: 350 }}>
+                <BarChart
+                  horizontal={boolean('horizontal', false)}
+                  width={350}
+                  height={350}
+                  domainPadding={object('domainPadding', { x: 15 })}
+                  data={Array(number('data', 5))
+                    .fill(null)
+                    .map((_, index) => ({
+                      x: `${index}-${index}`,
+                      y: rand()
+                    }))}
+                  parts={{
+                    axis: {
+                      dependent: {
+                        tickValues: [10, 50, 90],
+                        tickFormat: ['10%', '50%', '90%']
+                      }
                     }
-                  }
-                }}
-              />
+                  }}
+                />
+              </div>
               <CustomPopover
                 open={el != null}
                 anchorEl={el}


### PR DESCRIPTION
## Description

`ChartContainer` needs to support `variant` (similar to how `InsightContainer`) for it to be useful in profile pages as well as normal content pages, for example as **Featured Data** on project homepage.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Peek 2020-01-23 12-18](https://user-images.githubusercontent.com/1779590/72974578-49e5ff80-3de0-11ea-97f8-5e520281c8ec.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation