### PR TITLE
[Hotfix] Use indicatorId on searchParam

### DIFF
--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -19,11 +19,11 @@ export const uploadImage = (id, dataUrl, endPoint) =>
   });
 
 export const shareIndicator = (id, geoId, endPoint, e, dataUrl) => {
-  const uniqueId = geoId ? `${geoId}_${id}` : id;
-  uploadImage(uniqueId, dataUrl, endPoint).then(success => {
+  const indicatorId = geoId ? `${geoId}_${id}` : id;
+  uploadImage(indicatorId, dataUrl, endPoint).then(success => {
     if (success) {
       const url = new URL(window.location);
-      url.searchParams.set('indicatorId', id);
+      url.searchParams.set('indicatorId', indicatorId);
       window.open(`https://twitter.com/intent/tweet?url=${escape(url.href)}`);
     }
   });


### PR DESCRIPTION
## Description

Old `id` was being used on `url.searchParam` instead of the `indicatorId` which may include `geoId` if present.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation