### PR TITLE
[HotFix] PieChart donut label data selection

### DIFF
--- a/src/core/PieChart/index.js
+++ b/src/core/PieChart/index.js
@@ -209,7 +209,6 @@ function PieChart({
               colorScale={colorScale}
               highlightIndex={chart.donutHighlightIndex}
               highlightStyle={chart.donutHighlightStyle}
-              index={donutLabelKey.columnIndex}
               sortKey={donutLabelKey.sortKey}
               style={donutLabelStyle}
               text={

--- a/src/core/PieChart/index.js
+++ b/src/core/PieChart/index.js
@@ -121,7 +121,8 @@ function PieChart({
   };
 
   // Label & tooltip
-  const donutLabelData = data2 ? data[donutLabelKey.dataIndex] : data1;
+  const donutLabelData =
+    data2 && donutLabelKey.dataIndex ? data[donutLabelKey.dataIndex] : data1;
   const { style: suggestedStyle } = props;
   const donutLabelStyle = {
     textAnchor: 'middle',
@@ -287,7 +288,7 @@ PieChart.propTypes = {
   data: propTypes.groupedData,
   donut: PropTypes.bool,
   donutLabelKey: PropTypes.shape({
-    dataIndex: PropTypes.number.isRequired,
+    dataIndex: PropTypes.number,
     columnIndex: PropTypes.number,
     sortKey: PropTypes.oneOf(['value', '-value'])
   }),

--- a/src/core/PieChart/index.js
+++ b/src/core/PieChart/index.js
@@ -209,9 +209,13 @@ function PieChart({
               colorScale={colorScale}
               highlightIndex={chart.donutHighlightIndex}
               highlightStyle={chart.donutHighlightStyle}
+              index={donutLabelKey.columnIndex}
               sortKey={donutLabelKey.sortKey}
               style={donutLabelStyle}
-              text={data1[0].donutLabel || data1[0].label}
+              text={
+                donutLabelData[donutLabelKey.columnIndex || 0].donutLabel ||
+                donutLabelData[donutLabelKey.columnIndex || 0].label
+              }
               width={chartInnerRadius * 2}
               x={origin.x}
               y={origin.y}
@@ -285,6 +289,7 @@ PieChart.propTypes = {
   donut: PropTypes.bool,
   donutLabelKey: PropTypes.shape({
     dataIndex: PropTypes.number.isRequired,
+    columnIndex: PropTypes.number,
     sortKey: PropTypes.oneOf(['value', '-value'])
   }),
   groupSpacing: PropTypes.number,
@@ -325,7 +330,7 @@ PieChart.defaultProps = {
   colorScale: undefined,
   data: undefined,
   donut: undefined,
-  donutLabelKey: { dataIndex: 0, sortKey: undefined },
+  donutLabelKey: { dataIndex: 0, columnIndex: 0, sortKey: undefined },
   groupSpacing: undefined,
   height: undefined,
   innerRadius: undefined,

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -291,7 +291,11 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
             }
           ])}
           donut={boolean('donut', true)}
-          donutLabelKey={object('donutLabelKey', { dataIndex: 0 })}
+          donutLabelKey={object('donutLabelKey', {
+            dataIndex: 0,
+            columnIndex: 0,
+            sortKey: 'value'
+          })}
           height={height}
           labels={({ datum }) => labels(datum)}
           legendWidth={legendWidth}
@@ -359,7 +363,11 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
             ]
           ])}
           donut={boolean('donut', true)}
-          donutLabelKey={object('donutLabelKey', { dataIndex: 0 })}
+          donutLabelKey={object('donutLabelKey', {
+            dataIndex: 0,
+            columnIndex: 0,
+            sortKey: 'value'
+          })}
           groupSpacing={number('groupSpacing', 4)}
           height={height}
           parts={{


### PR DESCRIPTION
## Description

One should be able to:
 - [x] Select which data to use (in comparison mode), and
 - [x] Select which column in the data array  to use

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Screenshots

![Peek 2020-02-12 11-30](https://user-images.githubusercontent.com/1779590/74317282-2b927480-4d8c-11ea-95de-4320e9fe2cbe.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation