### PR TITLE
Split computation of max label dimension to avoid many hooks being invoked

### DIFF
--- a/src/core/WrapLabel/index.js
+++ b/src/core/WrapLabel/index.js
@@ -3,28 +3,13 @@ import PropTypes from 'prop-types';
 import shortid from 'shortid';
 
 import wrapSVGText from './wrapSVGText';
-import propTypes from '../propTypes';
 
 const WrapLabel = React.memo(
-  ({
-    width,
-    text,
-    x,
-    y,
-    style,
-    transform,
-    textAnchor,
-    horizontal,
-    onMaxDimmension
-  }) => {
+  ({ width, text, x, y, style, transform, textAnchor }) => {
     return (
       <text
         key={shortid.generate()}
-        ref={node => {
-          if (node) {
-            wrapSVGText(node, text, width, onMaxDimmension, horizontal);
-          }
-        }}
+        ref={node => wrapSVGText(node, text, width)}
         x={x}
         y={y}
         style={style}
@@ -49,14 +34,10 @@ WrapLabel.propTypes = {
   transform: PropTypes.string,
   width: PropTypes.number.isRequired,
   x: PropTypes.number,
-  y: PropTypes.number,
-  horizontal: propTypes.bool,
-  onMaxDimmension: propTypes.func
+  y: PropTypes.number
 };
 
 WrapLabel.defaultProps = {
-  horizontal: false,
-  onMaxDimmension: () => {},
   text: undefined,
   style: undefined,
   textAnchor: undefined,

--- a/src/core/WrapLabel/wrapSVGText.js
+++ b/src/core/WrapLabel/wrapSVGText.js
@@ -1,15 +1,79 @@
-export default (textElement, text, width, onMaxDimmension, horizontal) => {
+export function computeMaxLabelDimmension({ initialWidth, horizontal, texts }) {
   let maxDimmension = 0;
 
+  const lineHeight = '14';
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  const textEl = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  svg.setAttribute('opacity', '0');
+  document.body.appendChild(svg);
+  svg.appendChild(textEl);
+
+  const text =
+    texts.length > 1
+      ? texts.reduce((a, b) => (a.length > b.length ? a : b), '')
+      : texts[0] || '';
+
+  let line = [];
   const words = text.split(/\s+/).reverse();
   let word = words.pop();
-  let line = [];
-  const lineHeight = 14;
-  const x = textElement.getAttribute('x');
+
+  let tspan = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
+  tspan.setAttribute('text-anchor', 'middle');
+  textEl.appendChild(tspan);
+
+  while (word) {
+    line.push(word);
+    tspan.textContent = line.join(' ');
+    let { width, height } = tspan.getBoundingClientRect();
+    if (width > initialWidth) {
+      line.pop();
+      tspan.textContent = line.join(' ');
+      line = [word];
+
+      ({ width, height } = tspan.getBoundingClientRect());
+      if (horizontal) {
+        maxDimmension += height;
+      } else if (width > maxDimmension) {
+        maxDimmension = width;
+      } else {
+        // Nothing
+      }
+
+      tspan = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
+      tspan.setAttribute('text-anchor', 'middle');
+      tspan.setAttribute('dy', lineHeight);
+      tspan.textContent = word;
+    } else if (horizontal) {
+      maxDimmension += height;
+    } else if (width > maxDimmension) {
+      maxDimmension = width;
+    } else {
+      // Nothing
+    }
+
+    word = words.pop();
+  }
+
+  document.body.removeChild(svg);
+
+  return maxDimmension;
+}
+
+export default (textElement, text, initialWidth) => {
+  if (!textElement) {
+    return;
+  }
+
+  const words = text.split(/\s+/).reverse();
   const textAnchor = textElement.getAttribute('text-anchor');
+  const x = textElement.getAttribute('x');
+  const lineHeight = '14';
   const dy = 0;
   const dx = 0;
 
+  let line = [];
+  let word = words.pop();
   let tspan = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
   tspan.setAttribute('text-anchor', textAnchor || 'middle');
 
@@ -23,26 +87,20 @@ export default (textElement, text, width, onMaxDimmension, horizontal) => {
     tspan.setAttribute('dx', dx);
   }
   textElement.appendChild(tspan);
+
   while (word) {
     line.push(word);
     tspan.textContent = line.join(' ');
-    if (tspan.getBoundingClientRect().width > width) {
+
+    if (tspan.getBoundingClientRect().width > initialWidth) {
       line.pop();
       tspan.textContent = line.join(' ');
       line = [word];
 
-      if (horizontal) {
-        maxDimmension += tspan.getBoundingClientRect().height;
-      } else if (tspan.getBoundingClientRect().width > maxDimmension) {
-        maxDimmension = tspan.getBoundingClientRect().width;
-      } else {
-        // Nothing
-      }
-
       tspan = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
-      tspan.textContent = word;
       tspan.setAttribute('text-anchor', textAnchor || 'middle');
-      tspan.setAttribute('dy', lineHeight.toString());
+      tspan.setAttribute('dy', lineHeight);
+      tspan.textContent = word;
 
       if (x) {
         tspan.setAttribute('x', x);
@@ -51,16 +109,7 @@ export default (textElement, text, width, onMaxDimmension, horizontal) => {
         tspan.setAttribute('dx', dx);
       }
       textElement.appendChild(tspan);
-    } else if (horizontal) {
-      maxDimmension += tspan.getBoundingClientRect().height;
-    } else if (tspan.getBoundingClientRect().width > maxDimmension) {
-      maxDimmension = tspan.getBoundingClientRect().width;
-    } else {
-      // Nothing
     }
-
     word = words.pop();
   }
-
-  onMaxDimmension(maxDimmension);
 };


### PR DESCRIPTION
## Description

Split computation of max label dimension to avoid many hooks being invoked

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation