### PR TITLE
Fix undefined Indicator type

### DIFF
--- a/packages/content/src/dataProps.js
+++ b/packages/content/src/dataProps.js
@@ -32,7 +32,8 @@ import {
 export const TYPES = {
   HURUMAP_CARD: 'hurumap-card',
   HURUMAP_CHART: 'indicator-hurumap',
-  FLOURISH_CHART: 'indicator-flourish'
+  FLOURISH_CHART: 'indicator-flourish',
+  INDICATOR_WIDGET: 'indicator-block'
 };
 
 export function dataProps(
@@ -128,7 +129,7 @@ export function deprecatedProps(
    */
   return pickBy(
     {
-      id: id || `${type}-${chartId}`,
+      id: id || `${type}-${chartId || postId }`,
       style: pickBy(
         {
           // Margins are deprecated in favor of wp align classnames


### PR DESCRIPTION
## Description

On production, Indicator widget type is undefined. Missing from attributes
 
![Screenshot from 2020-03-12 11-47-12](https://user-images.githubusercontent.com/7962097/76503632-3d346e00-6457-11ea-916d-1ecf45104806.png)

Also, hurumap card while trying to fix this [issue](https://github.com/TakwimuAfrica/Dashboard/pull/71) I get,

![Screenshot from 2020-03-12 15-55-33](https://user-images.githubusercontent.com/7962097/76523772-0885de00-647a-11ea-9c08-e4c917802781.png)



Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation