### PR TITLE
Math Is In Session -  Fix show more and show less data calculations

### DIFF
--- a/packages/charts/src/BarChart/index.js
+++ b/packages/charts/src/BarChart/index.js
@@ -56,7 +56,7 @@ function BarChart({
     labelWidth = (offset || barWidth) * groupData.length;
   }
 
-  const maxLabelDimmension = useMemo(
+  const { maxLabelHeight, maxLabelWidth } = useMemo(
     () =>
       propMaxLabelDimmension ||
       computeMaxLabelDimmension({
@@ -115,12 +115,10 @@ function BarChart({
   );
 
   padding.left =
-    horizontal && maxLabelDimmension && maxLabelDimmension > padding.left
-      ? maxLabelDimmension
-      : padding.left;
+    horizontal && maxLabelHeight > padding.left ? maxLabelHeight : padding.left;
   padding.bottom =
-    !horizontal && maxLabelDimmension && maxLabelDimmension > padding.bottom
-      ? maxLabelDimmension
+    !horizontal && maxLabelWidth > padding.bottom
+      ? maxLabelWidth
       : padding.bottom;
 
   const chartProps = {
@@ -196,7 +194,10 @@ function BarChart({
 BarChart.propTypes = {
   data: propTypes.groupedData,
   barWidth: PropTypes.number,
-  maxLabelDimmension: PropTypes.number,
+  maxLabelDimmension: PropTypes.shape({
+    maxLabelWidth: PropTypes.number,
+    maxLabelHeight: PropTypes.number
+  }),
   labelWidth: PropTypes.number,
   domain: PropTypes.oneOfType([PropTypes.number, PropTypes.shape({})]),
   domainPadding: PropTypes.oneOfType([PropTypes.number, PropTypes.shape({})]),

--- a/packages/charts/src/BarChart/index.js
+++ b/packages/charts/src/BarChart/index.js
@@ -32,6 +32,7 @@ function BarChart({
   parts,
   responsive,
   theme,
+  maxLabelDimmension: propMaxLabelDimmension,
   width: suggestedWidth,
   ...props
 }) {
@@ -46,21 +47,24 @@ function BarChart({
     () => (!propData ? [] : Array.isArray(propData[0]) ? propData : [propData]),
     [propData]
   );
-  const barSpacing = offset || barWidth;
-  let labelWidth = barSpacing * groupData.length;
+
+  let labelWidth;
   const desiredLabelWidth = propLabelWidth || themeLabelWidth;
   if (horizontal && desiredLabelWidth) {
     labelWidth = desiredLabelWidth;
+  } else {
+    labelWidth = (offset || barWidth) * groupData.length;
   }
 
   const maxLabelDimmension = useMemo(
     () =>
+      propMaxLabelDimmension ||
       computeMaxLabelDimmension({
         labelWidth,
         horizontal,
         texts: groupData.reduce((a, b) => a.concat(b.map(({ x }) => x)), [])
       }),
-    [labelWidth, horizontal, groupData]
+    [labelWidth, propMaxLabelDimmension, horizontal, groupData]
   );
 
   if (!propData || !groupChart) {
@@ -192,6 +196,7 @@ function BarChart({
 BarChart.propTypes = {
   data: propTypes.groupedData,
   barWidth: PropTypes.number,
+  maxLabelDimmension: PropTypes.number,
   labelWidth: PropTypes.number,
   domain: PropTypes.oneOfType([PropTypes.number, PropTypes.shape({})]),
   domainPadding: PropTypes.oneOfType([PropTypes.number, PropTypes.shape({})]),
@@ -214,6 +219,7 @@ BarChart.propTypes = {
 };
 
 BarChart.defaultProps = {
+  maxLabelDimmension: undefined,
   barWidth: undefined,
   labelWidth: undefined,
   data: undefined,

--- a/packages/charts/src/BarChart/index.js
+++ b/packages/charts/src/BarChart/index.js
@@ -111,9 +111,13 @@ function BarChart({
   );
 
   padding.left =
-    horizontal && maxLabelDimmension ? maxLabelDimmension / 2 : padding.left;
+    horizontal && maxLabelDimmension && maxLabelDimmension > padding.left
+      ? maxLabelDimmension
+      : padding.left;
   padding.bottom =
-    !horizontal && maxLabelDimmension ? maxLabelDimmension * 2 : padding.bottom;
+    !horizontal && maxLabelDimmension && maxLabelDimmension > padding.bottom
+      ? maxLabelDimmension
+      : padding.bottom;
 
   const chartProps = {
     domain,

--- a/packages/charts/src/ChartFactory.js
+++ b/packages/charts/src/ChartFactory.js
@@ -308,7 +308,11 @@ const ChartFactory = React.memo(
             ? padding.top + padding.bottom
             : padding.left + padding.right;
           const computedSize =
-            dataCount * barCount * offset + paddingSize + offset;
+            (dataCount > primaryData.length ? primaryData.length : dataCount) *
+              barCount *
+              offset +
+            paddingSize +
+            offset;
 
           const showHorizontal =
             horizontal || computedSize > adjustedDimmension;

--- a/packages/charts/src/ChartFactory.js
+++ b/packages/charts/src/ChartFactory.js
@@ -215,7 +215,7 @@ const ChartFactory = React.memo(
             : padding.left + padding.right;
 
           const rootWidth = rootRef && rootRef.getBoundingClientRect().width;
-          const labelWidth = computeMaxLabelDimmension({
+          const maxLabelDimmension = computeMaxLabelDimmension({
             horizontal,
             labelWidth: theme.axis.labelWidth,
             texts: primaryData.reduce(
@@ -225,7 +225,7 @@ const ChartFactory = React.memo(
           });
 
           const adjustedRootWidth =
-            rootWidth && rootWidth - (horizontal ? labelWidth || 0 : 0);
+            rootWidth && rootWidth - (horizontal ? maxLabelDimmension || 0 : 0);
           const height = heightProp || theme.bar.height;
 
           const totalColumnCount = showMore
@@ -253,6 +253,7 @@ const ChartFactory = React.memo(
             columnCount,
             domainPadding,
             height: computedHeight,
+            maxLabelDimmension,
             enableShowMore:
               showMore ||
               totalColumnCount !== primaryData.length * primaryData[0].length
@@ -276,8 +277,14 @@ const ChartFactory = React.memo(
             : padding.left + padding.right;
 
           const rootWidth = rootRef && rootRef.getBoundingClientRect().width;
+          const maxLabelDimmension = computeMaxLabelDimmension({
+            horizontal,
+            labelWidth: theme.axis.labelWidth,
+            texts: primaryData.map(({ x }) => x)
+          });
+
           const adjustedRootWidth =
-            rootWidth && rootWidth - (theme.axis.labelWidth || 0);
+            rootWidth && rootWidth - (maxLabelDimmension || 0);
           const height = heightProp || theme.bar.height;
 
           const dataCount = showMore
@@ -305,6 +312,7 @@ const ChartFactory = React.memo(
             offset,
             dataCount,
             domainPadding,
+            maxLabelDimmension,
             height: computedHeight,
             enableShowMore: showMore || dataCount !== primaryData.length
           };
@@ -477,7 +485,8 @@ const ChartFactory = React.memo(
             width,
             groupCount,
             columnCount,
-            domainPadding
+            domainPadding,
+            maxLabelDimmension
           } = calculations;
 
           return (
@@ -495,6 +504,7 @@ const ChartFactory = React.memo(
                 labels={({ datum }) => format(datum.y)}
                 padding={paddingProp}
                 theme={theme}
+                maxLabelDimmension={maxLabelDimmension}
                 {...chartProps}
               />
             </div>
@@ -506,7 +516,8 @@ const ChartFactory = React.memo(
             height,
             width,
             dataCount,
-            domainPadding
+            domainPadding,
+            maxLabelDimmension
           } = calculations;
           if (isComparison) {
             const processedComparisonData = aggregate
@@ -528,6 +539,7 @@ const ChartFactory = React.memo(
                   domainPadding={domainPadding}
                   labels={({ datum }) => format(datum.y)}
                   theme={theme}
+                  maxLabelDimmension={maxLabelDimmension}
                   {...chartProps}
                 />
               </div>
@@ -545,6 +557,7 @@ const ChartFactory = React.memo(
                 domainPadding={domainPadding}
                 labels={({ datum }) => format(datum.y)}
                 theme={theme}
+                maxLabelDimmension={maxLabelDimmension}
                 {...chartProps}
               />
             </div>

--- a/packages/charts/src/ChartFactory.js
+++ b/packages/charts/src/ChartFactory.js
@@ -228,9 +228,10 @@ const ChartFactory = React.memo(
             rootWidth && rootWidth - (horizontal ? maxLabelDimmension || 0 : 0);
           const height = heightProp || theme.bar.height;
 
-          const totalColumnCount = showMore
-            ? primaryData.length * primaryData[0].length
-            : Math.floor((adjustedRootWidth - paddingSize) / offset);
+          const totalColumnCount =
+            showMore || disableShowMore
+              ? primaryData.length * primaryData[0].length
+              : Math.floor((adjustedRootWidth - paddingSize) / offset);
 
           const columnCount =
             totalColumnCount > primaryData.length
@@ -255,8 +256,9 @@ const ChartFactory = React.memo(
             height: computedHeight,
             maxLabelDimmension,
             enableShowMore:
-              showMore ||
-              totalColumnCount !== primaryData.length * primaryData[0].length
+              !disableShowMore &&
+              (showMore ||
+                totalColumnCount !== primaryData.length * primaryData[0].length)
           };
         }
         case 'column': {
@@ -287,14 +289,15 @@ const ChartFactory = React.memo(
             rootWidth && rootWidth - (maxLabelDimmension || 0);
           const height = heightProp || theme.bar.height;
 
-          const dataCount = showMore
-            ? primaryData.length
-            : Math.floor(
-                (adjustedRootWidth -
-                  (primaryData.length === 2 ? offset : 0) -
-                  paddingSize) /
-                  (offset * barCount)
-              );
+          const dataCount =
+            showMore || disableShowMore
+              ? primaryData.length
+              : Math.floor(
+                  (adjustedRootWidth -
+                    (primaryData.length === 2 ? offset : 0) -
+                    paddingSize) /
+                    (offset * barCount)
+                );
           const computedSize =
             primaryData.length * barCount * offset +
             paddingSize +
@@ -314,7 +317,8 @@ const ChartFactory = React.memo(
             domainPadding,
             maxLabelDimmension,
             height: computedHeight,
-            enableShowMore: showMore || dataCount !== primaryData.length
+            enableShowMore:
+              !disableShowMore && (showMore || dataCount !== primaryData.length)
           };
         }
         case 'line': {
@@ -344,12 +348,13 @@ const ChartFactory = React.memo(
       theme.line.offset,
       theme.line.height,
       heightProp,
-      primaryData,
       offsetProp,
       paddingProp,
+      primaryData,
       horizontal,
       rootRef,
       showMore,
+      disableShowMore,
       isComparison
     ]);
 

--- a/packages/charts/src/WrapLabel/wrapSVGText.js
+++ b/packages/charts/src/WrapLabel/wrapSVGText.js
@@ -1,5 +1,6 @@
-export function computeMaxLabelDimmension({ initialWidth, horizontal, texts }) {
-  let maxDimmension = 0;
+export function computeMaxLabelDimmension({ initialWidth, texts }) {
+  let maxLabelWidth = 0;
+  let maxLabelHeight = 0;
 
   const lineHeight = '14';
 
@@ -32,24 +33,20 @@ export function computeMaxLabelDimmension({ initialWidth, horizontal, texts }) {
       line = [word];
 
       ({ width, height } = tspan.getBoundingClientRect());
-      if (horizontal) {
-        maxDimmension += height;
-      } else if (width > maxDimmension) {
-        maxDimmension = width;
-      } else {
-        // Nothing
+      maxLabelHeight += height;
+      if (width > maxLabelWidth) {
+        maxLabelWidth = width;
       }
 
       tspan = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
       tspan.setAttribute('text-anchor', 'middle');
       tspan.setAttribute('dy', lineHeight);
       tspan.textContent = word;
-    } else if (horizontal) {
-      maxDimmension += height;
-    } else if (width > maxDimmension) {
-      maxDimmension = width;
     } else {
-      // Nothing
+      maxLabelHeight += height;
+      if (width > maxLabelWidth) {
+        maxLabelWidth = width;
+      }
     }
 
     word = words.pop();
@@ -57,7 +54,7 @@ export function computeMaxLabelDimmension({ initialWidth, horizontal, texts }) {
 
   document.body.removeChild(svg);
 
-  return maxDimmension;
+  return { maxLabelWidth, maxLabelHeight };
 }
 
 export default (textElement, text, initialWidth) => {

--- a/stories/container.stories.js
+++ b/stories/container.stories.js
@@ -300,7 +300,10 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
         aggregate: 'raw'
       });
 
-      const dataArray = Array(((definition.groupBy && groups) || 1) * data)
+      const dataArray = Array(
+        ((definition.groupBy && definition.type === 'group' && groups) || 1) *
+          data
+      )
         .fill(null)
         .map((_, index) => ({
           groupBy:

--- a/stories/container.stories.js
+++ b/stories/container.stories.js
@@ -301,8 +301,10 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
       });
 
       const dataArray = Array(
-        ((definition.groupBy && definition.type === 'group' && groups) || 1) *
-          data
+        ((definition.groupBy &&
+          definition.type === 'grouped_column' &&
+          groups) ||
+          1) * data
       )
         .fill(null)
         .map((_, index) => ({

--- a/stories/factory.stories.js
+++ b/stories/factory.stories.js
@@ -25,7 +25,7 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
     );
     const horizontal = boolean('horizontal');
     const data = Array(number('data', 3)).fill(null);
-    const toggleSize = type === 'column' && boolean('toggleSize', true);
+    const disableShowMore = type === 'column' && boolean('disableShowMore', true);
     const customUnit = text('customUnit', 'unit');
     const aggregate = select('aggregate', [':percent', ''], '');
     const subtitle = text('subtitle', 'Subtitle');
@@ -61,7 +61,7 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
             y
           };
         })}
-        toggleSize={toggleSize}
+        disableShowMore={disableShowMore}
       />
     );
   })

--- a/stories/factory.stories.js
+++ b/stories/factory.stories.js
@@ -14,7 +14,7 @@ import { CenterDecorator } from './common';
 
 const rand = () => Number((Math.random() * 100).toFixed(1));
 
-storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
+storiesOf('HURUmap UI|Charts/ChartFactory', module)
   .addDecorator(CenterDecorator)
   .addDecorator(withKnobs)
   .add('Default', () => {
@@ -25,7 +25,8 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
     );
     const horizontal = boolean('horizontal');
     const data = Array(number('data', 3)).fill(null);
-    const disableShowMore = type === 'column' && boolean('disableShowMore', true);
+    const disableShowMore =
+      type === 'column' && boolean('disableShowMore', true);
     const customUnit = text('customUnit', 'unit');
     const aggregate = select('aggregate', [':percent', ''], '');
     const subtitle = text('subtitle', 'Subtitle');
@@ -68,6 +69,8 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
   .add('Grouped', () => {
     const type = select('type', ['grouped_column', 'number'], 'grouped_column');
     const horizontal = boolean('horizontal');
+    const disableShowMore =
+      type === 'grouped_column' && boolean('disableShowMore', true);
     const groups = number('groups', 2);
     const data = Array(number('data', 2) * groups).fill(null);
     const aggregate = select(
@@ -102,6 +105,7 @@ storiesOf('HURUmap UI|Charts Factory/ChartFactory', module)
           description,
           statistic
         }}
+        disableShowMore={disableShowMore}
         data={data.map((_, index) => {
           const y = rand();
           return {


### PR DESCRIPTION
## Description

- Group charts truncate group columns first then truncate groups
- Use math instead of for loops

Resolves #123 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![](http://g.recordit.co/Q18Iqkm9Us.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation