### PR TITLE
Snippet Title

### DIFF
--- a/packages/core/src/Snippet/Actions.js
+++ b/packages/core/src/Snippet/Actions.js
@@ -8,10 +8,10 @@ import ShareIcon from '../assets/icons/network-connection.svg';
 import makeStyles from '../makeStyles';
 
 const useStyles = makeStyles({
-  actionsContainer: {
+  root: {
     right: 20,
     color: 'white',
-    padding: '2px 5px',
+    padding: '2px 0 2px 5px',
     borderRadius: 5
   },
   actionButton: {
@@ -22,10 +22,10 @@ const useStyles = makeStyles({
   }
 });
 
-function SnippetActions({ onShare, onEmbed }) {
-  const classes = useStyles();
+function SnippetActions({ onShare, onEmbed, ...props }) {
+  const classes = useStyles(props);
   return (
-    <Grid className={classes.actionsContainer} container spacing={0}>
+    <Grid className={classes.root} container spacing={0}>
       <Grid item>
         <ActionButton
           classes={{

--- a/packages/core/src/Snippet/index.js
+++ b/packages/core/src/Snippet/index.js
@@ -5,6 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import AddIcon from '@material-ui/icons/Add';
 import MinimizeIcon from '@material-ui/icons/Remove';
 
+import classNames from 'classnames';
 import shortid from 'shortid';
 import { Link } from '@material-ui/core';
 
@@ -33,7 +34,15 @@ const useStyles = makeStyles(theme => ({
       objectFit: 'cover'
     }
   }),
-  cardButton: {}
+  actionsRoot: {
+    justifyContent: 'flex-end',
+    width: '5rem'
+  },
+  cardButton: {},
+  title: {
+    fontSize: '1.25rem',
+    fontWeight: 'bold'
+  }
 }));
 
 function Snippet({
@@ -106,12 +115,24 @@ function Snippet({
               justify="space-between"
             >
               <Grid item>
-                <Typography dangerouslySetInnerHTML={{ __html: post.title }} />
+                <Typography
+                  className={classes.title}
+                  dangerouslySetInnerHTML={{ __html: post.title }}
+                />
               </Grid>
-              <Grid item className={DOWNLOAD_HIDDEN_CLASSNAME}>
+              <Grid
+                item
+                className={classNames(
+                  classes.actions,
+                  DOWNLOAD_HIDDEN_CLASSNAME
+                )}
+              >
                 {!link && (
                   <>
                     <SnippetActions
+                      classes={{
+                        root: classes.actionsRoot
+                      }}
                       onEmbed={e => showActionsModal(EMBED_TAB, e)}
                       onShare={e => showActionsModal(SHARE_TAB, e)}
                     />

--- a/stories/snippet.stories.js
+++ b/stories/snippet.stories.js
@@ -20,7 +20,7 @@ storiesOf('HURUmap UI|Snippets/Default', module)
         twitter: {}
       })}
       post={{
-        title: 'Development Context',
+        title: 'Development context but with added words to show long title',
         content: decodeHTML(
           text(
             'Content (ReadMore split; <p><!--more--></p>)',


### PR DESCRIPTION
## Description

Current Snippet title uses the same font as text and doesn't accommodate long titles very well

 - [x] Snippet title should be bold with same font as `InsightContainer`, and
 - [x] Snippet title should wrap without causing actions on the right of the snippet to wrap as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/77311231-c7f75180-6d10-11ea-8554-e7454d16c122.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation