### PR TITLE
Fix use correct label dimmension for padding

### DIFF
--- a/packages/charts/src/BarChart/index.js
+++ b/packages/charts/src/BarChart/index.js
@@ -115,10 +115,10 @@ function BarChart({
   );
 
   padding.left =
-    horizontal && maxLabelHeight > padding.left ? maxLabelHeight : padding.left;
+    horizontal && maxLabelWidth > padding.left ? maxLabelWidth : padding.left;
   padding.bottom =
-    !horizontal && maxLabelWidth > padding.bottom
-      ? maxLabelWidth
+    !horizontal && maxLabelHeight > padding.bottom
+      ? maxLabelHeight
       : padding.bottom;
 
   const chartProps = {

--- a/packages/charts/src/ChartFactory.js
+++ b/packages/charts/src/ChartFactory.js
@@ -197,7 +197,6 @@ const ChartFactory = React.memo(
             height: heightProp || theme.pie.height
           };
         case 'grouped_column': {
-          const { barWidth } = theme.bar;
           const offset = offsetProp || theme.bar.offset;
           const padding = paddingProp
             ? Helpers.getPadding({ padding: paddingProp })
@@ -234,7 +233,7 @@ const ChartFactory = React.memo(
           const totalColumnCount =
             showMore || disableShowMore
               ? primaryData.length * primaryData[0].length
-              : Math.floor((adjustedDimmension - paddingSize) / barWidth);
+              : Math.floor((adjustedDimmension - paddingSize) / offset);
 
           const columnCount =
             totalColumnCount > primaryData.length
@@ -271,7 +270,6 @@ const ChartFactory = React.memo(
         }
         case 'column': {
           const barCount = isComparison ? 2 : 1;
-          const { barWidth } = theme.bar;
           const offset = offsetProp || theme.bar.offset;
           const {
             domainPadding: {
@@ -301,9 +299,9 @@ const ChartFactory = React.memo(
               ? primaryData.length
               : Math.floor(
                   (adjustedDimmension -
-                    barWidth -
+                    offset -
                     (padding.left + padding.right)) /
-                    barWidth
+                    offset
                 );
 
           const paddingSize = horizontal

--- a/packages/charts/src/ChartFactory.js
+++ b/packages/charts/src/ChartFactory.js
@@ -240,7 +240,7 @@ const ChartFactory = React.memo(
               ? primaryData.length
               : totalColumnCount;
 
-          const groupCount = Math.ceil(totalColumnCount / primaryData.length);
+          const groupCount = Math.floor(totalColumnCount / primaryData.length);
 
           const computedSize =
             (totalColumnCount > primaryData.length * primaryData[0].length

--- a/packages/charts/src/ChartFactory.js
+++ b/packages/charts/src/ChartFactory.js
@@ -197,6 +197,7 @@ const ChartFactory = React.memo(
             height: heightProp || theme.pie.height
           };
         case 'grouped_column': {
+          const { barWidth } = theme.bar;
           const offset = offsetProp || theme.bar.offset;
           const padding = paddingProp
             ? Helpers.getPadding({ padding: paddingProp })
@@ -233,7 +234,7 @@ const ChartFactory = React.memo(
           const totalColumnCount =
             showMore || disableShowMore
               ? primaryData.length * primaryData[0].length
-              : Math.floor((adjustedDimmension - paddingSize) / offset);
+              : Math.floor((adjustedDimmension - paddingSize) / barWidth);
 
           const columnCount =
             totalColumnCount > primaryData.length
@@ -270,6 +271,7 @@ const ChartFactory = React.memo(
         }
         case 'column': {
           const barCount = isComparison ? 2 : 1;
+          const { barWidth } = theme.bar;
           const offset = offsetProp || theme.bar.offset;
           const {
             domainPadding: {
@@ -299,9 +301,9 @@ const ChartFactory = React.memo(
               ? primaryData.length
               : Math.floor(
                   (adjustedDimmension -
-                    offset -
+                    barWidth -
                     (padding.left + padding.right)) /
-                    offset
+                    barWidth
                 );
 
           const paddingSize = horizontal

--- a/packages/charts/src/WrapLabel/wrapSVGText.js
+++ b/packages/charts/src/WrapLabel/wrapSVGText.js
@@ -1,5 +1,5 @@
 export function computeMaxLabelDimmension({ labelWidth, texts }) {
-  let maxLabelWidth = 0;
+  let maxLabelWidth = labelWidth;
   let maxLabelHeight = 0;
 
   const lineHeight = '14';

--- a/packages/charts/src/WrapLabel/wrapSVGText.js
+++ b/packages/charts/src/WrapLabel/wrapSVGText.js
@@ -1,4 +1,4 @@
-export function computeMaxLabelDimmension({ initialWidth, texts }) {
+export function computeMaxLabelDimmension({ labelWidth, texts }) {
   let maxLabelWidth = 0;
   let maxLabelHeight = 0;
 
@@ -27,7 +27,8 @@ export function computeMaxLabelDimmension({ initialWidth, texts }) {
     line.push(word);
     tspan.textContent = line.join(' ');
     let { width, height } = tspan.getBoundingClientRect();
-    if (width > initialWidth) {
+    maxLabelHeight += height;
+    if (width > labelWidth) {
       line.pop();
       tspan.textContent = line.join(' ');
       line = [word];
@@ -42,11 +43,6 @@ export function computeMaxLabelDimmension({ initialWidth, texts }) {
       tspan.setAttribute('text-anchor', 'middle');
       tspan.setAttribute('dy', lineHeight);
       tspan.textContent = word;
-    } else {
-      maxLabelHeight += height;
-      if (width > maxLabelWidth) {
-        maxLabelWidth = width;
-      }
     }
 
     word = words.pop();
@@ -57,7 +53,7 @@ export function computeMaxLabelDimmension({ initialWidth, texts }) {
   return { maxLabelWidth, maxLabelHeight };
 }
 
-export default (textElement, text, initialWidth) => {
+export default (textElement, text, labelWidth) => {
   if (!textElement) {
     return;
   }
@@ -89,7 +85,7 @@ export default (textElement, text, initialWidth) => {
     line.push(word);
     tspan.textContent = line.join(' ');
 
-    if (tspan.getBoundingClientRect().width > initialWidth) {
+    if (tspan.getBoundingClientRect().width > labelWidth) {
       line.pop();
       tspan.textContent = line.join(' ');
       line = [word];

--- a/stories/card.stories.js
+++ b/stories/card.stories.js
@@ -84,9 +84,9 @@ storiesOf('HURUmap UI|Components/Card', module)
       >
         <div style={{ width, height: '100%' }}>
           <Card
-            id="1234"
+            key={JSON.stringify(definition)}
+            id={definition.id}
             logo={logo}
-            key={type}
             type={type}
             geoId={geoId}
             definition={definition}

--- a/stories/container.stories.js
+++ b/stories/container.stories.js
@@ -282,8 +282,6 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
       const containerWidth = number('containerWidth', 950);
       const hideInsight = boolean('hideInsight');
       const variant = select('variant', ['data', 'analysis'], 'data');
-      const chartHeight = number('chartHeight');
-      const chartWidth = number('chartWidth');
       const groups = number('groups', 3);
       const data = number('data', 2);
       const dataExponent = number('Data value E+', 6);
@@ -343,19 +341,7 @@ storiesOf('HURUmap UI|ChartContainers/InsightChartContainer', module)
             variant={variant}
           >
             <ChartFactory definition={statisticDefinition} data={dataArray} />
-            <ChartFactory
-              definition={{
-                ...definition,
-                typeProps: {
-                  height: chartHeight,
-                  width:
-                    variant === 'analysis' && !chartWidth
-                      ? containerWidth
-                      : chartWidth
-                }
-              }}
-              data={dataArray}
-            />
+            <ChartFactory definition={definition} data={dataArray} />
           </InsightContainer>
         </div>
       );

--- a/stories/theme.js
+++ b/stories/theme.js
@@ -4,6 +4,12 @@ export default createTheme({
   chart: {
     axis: {
       labelWidth: 150
+    },
+    bar: {
+      width: 350,
+      height: 350,
+      barWidth: 30,
+      offset: 60
     }
   }
 });

--- a/stories/theme.js
+++ b/stories/theme.js
@@ -7,9 +7,9 @@ export default createTheme({
     },
     bar: {
       width: 350,
-      height: 350,
+      height: 300,
       barWidth: 30,
-      offset: 60
+      offset: 40
     }
   }
 });


### PR DESCRIPTION
## Description

- Use the correct label dimension for the corresponding padding
- Use the the barWidth to find the amount of bars that  can fit a chart instead of the offset

Test with:

graphql -> https://graphql.hurumap.org/graphql

definition -> 
```
{
  "id": 668,
  "title": "Contribution by principal donor",
  "subtitle": "Development Assistance",
  "visual": {
    "type": "column",
    "table": "allGlobalHealthSecurityIndices",
    "x": "category",
    "y": "score",
    "typeProps": {
      "horizontal": false
    },
    "queryAlias": "v668"
  },
  "stat": {
    "type": "number",
    "subtitle": "Development Assistance",
    "description": "Donor Contribution",
    "unique": false,
    "aggregate": "sum",
    "queryAlias": "v668"
  },
  "source": [],
  "description": []
}
```

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation