### PR TITLE
Grouped Data Legend

### DIFF
--- a/packages/charts/src/BarChart/index.js
+++ b/packages/charts/src/BarChart/index.js
@@ -9,7 +9,7 @@ import {
   VictoryLegend
 } from 'victory';
 
-import { computeMaxLabelDimmension } from '../WrapLabel/wrapSVGText';
+import { computeMaxLabelDimension } from '../WrapLabel/wrapSVGText';
 
 import { getLegendProps } from '../utils';
 import propTypes from '../propTypes';
@@ -32,7 +32,7 @@ function BarChart({
   parts,
   responsive,
   theme,
-  maxLabelDimmension: propMaxLabelDimmension,
+  maxLabelDimension: propMaxLabelDimension,
   width: suggestedWidth,
   ...props
 }) {
@@ -58,13 +58,13 @@ function BarChart({
 
   const { maxLabelHeight, maxLabelWidth } = useMemo(
     () =>
-      propMaxLabelDimmension ||
-      computeMaxLabelDimmension({
+      propMaxLabelDimension ||
+      computeMaxLabelDimension({
         labelWidth,
         horizontal,
         texts: groupData.reduce((a, b) => a.concat(b.map(({ x }) => x)), [])
       }),
-    [labelWidth, propMaxLabelDimmension, horizontal, groupData]
+    [labelWidth, propMaxLabelDimension, horizontal, groupData]
   );
 
   if (!propData || !groupChart) {
@@ -194,7 +194,7 @@ function BarChart({
 BarChart.propTypes = {
   data: propTypes.groupedData,
   barWidth: PropTypes.number,
-  maxLabelDimmension: PropTypes.shape({
+  maxLabelDimension: PropTypes.shape({
     maxLabelWidth: PropTypes.number,
     maxLabelHeight: PropTypes.number
   }),
@@ -220,7 +220,7 @@ BarChart.propTypes = {
 };
 
 BarChart.defaultProps = {
-  maxLabelDimmension: undefined,
+  maxLabelDimension: undefined,
   barWidth: undefined,
   labelWidth: undefined,
   data: undefined,

--- a/packages/charts/src/BarChart/index.js
+++ b/packages/charts/src/BarChart/index.js
@@ -11,7 +11,7 @@ import {
 
 import { computeMaxLabelDimension } from '../WrapLabel/wrapSVGText';
 
-import { getLegendProps } from '../utils';
+import { extractLegendData, getLegendProps } from '../utils';
 import propTypes from '../propTypes';
 import withVictoryTheme from '../styles/withVictoryTheme';
 import BarLabel from './BarLabel';
@@ -110,7 +110,7 @@ function BarChart({
   const { padding, legend } = getLegendProps(
     { height, width },
     initialLegendProps,
-    groupData[0],
+    extractLegendData(groupData),
     originalPadding
   );
 

--- a/packages/charts/src/ChartFactory.js
+++ b/packages/charts/src/ChartFactory.js
@@ -16,7 +16,7 @@ import NumberVisuals from './NumberVisuals';
 import propTypes from './propTypes';
 import withVictoryTheme from './styles/withVictoryTheme';
 
-import { computeMaxLabelDimmension } from './WrapLabel/wrapSVGText';
+import { computeMaxLabelDimension } from './WrapLabel/wrapSVGText';
 
 const DOWNLOAD_HIDDEN_CLASSNAME = 'Download--hidden';
 
@@ -123,8 +123,8 @@ const ChartFactory = React.memo(
 
     const primaryData = useMemo(() => {
       const labels = ({ x, y }, separator = ': ') => {
-        const formatedX = x ? `${x}${separator}` : '';
-        return `${formatedX}${format(y)}`;
+        const formattedX = x ? `${x}${separator}` : '';
+        return `${formattedX}${format(y)}`;
       };
 
       if (
@@ -133,18 +133,20 @@ const ChartFactory = React.memo(
       ) {
         /**
          * Group the data based on groupBy
-         * Then aggregate the groupped data
+         * Then aggregate the grouped data
          */
         let groupedData = groupData(data);
 
         if (groupedData.length) {
           /**
-           * Change `x` to be the `groupBy` value
+           * i. Show `x` in legend as name, and
+           * ii. Change `x` to be the `groupBy` value
            * to plot group labels on the dependent axis
            */
           groupedData = groupedData.map(g =>
             g.map(gd => ({
               ...gd,
+              name: gd.x,
               tooltip: labels(gd),
               x: gd.groupBy
             }))
@@ -178,8 +180,9 @@ const ChartFactory = React.memo(
           ...d,
           donutLabel: labels(d, '\n'),
           label: labels(d),
+          tooltip: labels(d),
           name: d.x,
-          tooltip: labels(d)
+          description: labels(d)
         }));
       }
       return [];
@@ -216,7 +219,7 @@ const ChartFactory = React.memo(
             : padding.left + padding.right;
 
           const rootWidth = rootRef && rootRef.getBoundingClientRect().width;
-          const { maxLabelHeight, maxLabelWidth } = computeMaxLabelDimmension({
+          const { maxLabelHeight, maxLabelWidth } = computeMaxLabelDimension({
             labelWidth: theme.axis.labelWidth,
             texts: primaryData.reduce(
               (a, b) => a.concat(b.map(({ x }) => x)),
@@ -227,14 +230,12 @@ const ChartFactory = React.memo(
           const height = heightProp || theme.bar.height;
           const adjustedHeight = height - maxLabelHeight;
           const adjustedWidth = rootWidth && rootWidth - maxLabelWidth;
-          const adjustedDimmension = horizontal
-            ? adjustedHeight
-            : adjustedWidth;
+          const adjustedDimension = horizontal ? adjustedHeight : adjustedWidth;
 
           const totalColumnCount =
             showMore || disableShowMore
               ? primaryData.length * primaryData[0].length
-              : Math.floor((adjustedDimmension - paddingSize) / offset);
+              : Math.floor((adjustedDimension - paddingSize) / offset);
 
           const columnCount =
             totalColumnCount > primaryData.length
@@ -250,8 +251,7 @@ const ChartFactory = React.memo(
               offset +
             paddingSize;
 
-          const showHorizontal =
-            horizontal || computedSize > adjustedDimmension;
+          const showHorizontal = horizontal || computedSize > adjustedDimension;
           const width = showHorizontal ? adjustedWidth : computedSize;
           const computedHeight = showHorizontal ? computedSize : height;
           return {
@@ -261,7 +261,7 @@ const ChartFactory = React.memo(
             columnCount,
             domainPadding,
             height: computedHeight,
-            maxLabelDimmension: { maxLabelHeight, maxLabelWidth },
+            maxLabelDimension: { maxLabelHeight, maxLabelWidth },
             showHorizontal,
             enableShowMore:
               !disableShowMore &&
@@ -283,7 +283,7 @@ const ChartFactory = React.memo(
             : Helpers.getPadding(theme.bar);
 
           const rootWidth = rootRef && rootRef.getBoundingClientRect().width;
-          const { maxLabelHeight, maxLabelWidth } = computeMaxLabelDimmension({
+          const { maxLabelHeight, maxLabelWidth } = computeMaxLabelDimension({
             labelWidth: theme.axis.labelWidth,
             texts: primaryData.map(({ x }) => x)
           });
@@ -291,15 +291,13 @@ const ChartFactory = React.memo(
           const height = heightProp || theme.bar.height;
           const adjustedHeight = height - maxLabelHeight;
           const adjustedWidth = rootWidth && rootWidth - maxLabelWidth;
-          const adjustedDimmension = horizontal
-            ? adjustedHeight
-            : adjustedWidth;
+          const adjustedDimension = horizontal ? adjustedHeight : adjustedWidth;
 
           const dataCount =
             showMore || disableShowMore
               ? primaryData.length
               : Math.floor(
-                  (adjustedDimmension -
+                  (adjustedDimension -
                     offset -
                     (padding.left + padding.right)) /
                     offset
@@ -315,8 +313,7 @@ const ChartFactory = React.memo(
             paddingSize +
             offset;
 
-          const showHorizontal =
-            horizontal || computedSize > adjustedDimmension;
+          const showHorizontal = horizontal || computedSize > adjustedDimension;
           const width = showHorizontal ? adjustedWidth : computedSize;
           const computedHeight = showHorizontal ? computedSize : height;
           return {
@@ -324,7 +321,7 @@ const ChartFactory = React.memo(
             offset,
             dataCount,
             domainPadding,
-            maxLabelDimmension: { maxLabelHeight, maxLabelWidth },
+            maxLabelDimension: { maxLabelHeight, maxLabelWidth },
             height: computedHeight,
             showHorizontal,
             enableShowMore:
@@ -501,7 +498,7 @@ const ChartFactory = React.memo(
             groupCount,
             columnCount,
             domainPadding,
-            maxLabelDimmension,
+            maxLabelDimension,
             showHorizontal
           } = calculations;
 
@@ -517,10 +514,10 @@ const ChartFactory = React.memo(
                 height={height}
                 horizontal={showHorizontal}
                 domainPadding={domainPadding}
-                labels={({ datum }) => format(datum.y)}
+                labels={({ datum }) => datum.tooltip || format(datum.y)}
                 padding={paddingProp}
                 theme={theme}
-                maxLabelDimmension={maxLabelDimmension}
+                maxLabelDimension={maxLabelDimension}
                 {...chartProps}
               />
             </div>
@@ -533,7 +530,7 @@ const ChartFactory = React.memo(
             width,
             dataCount,
             domainPadding,
-            maxLabelDimmension,
+            maxLabelDimension,
             showHorizontal
           } = calculations;
           if (isComparison) {
@@ -554,9 +551,9 @@ const ChartFactory = React.memo(
                   width={width}
                   horizontal={showHorizontal}
                   domainPadding={domainPadding}
-                  labels={({ datum }) => format(datum.y)}
+                  labels={({ datum }) => datum.tooltip || format(datum.y)}
                   theme={theme}
-                  maxLabelDimmension={maxLabelDimmension}
+                  maxLabelDimension={maxLabelDimension}
                   {...chartProps}
                 />
               </div>
@@ -572,9 +569,9 @@ const ChartFactory = React.memo(
                 width={width}
                 horizontal={showHorizontal}
                 domainPadding={domainPadding}
-                labels={({ datum }) => format(datum.y)}
+                labels={({ datum }) => datum.tooltip || format(datum.y)}
                 theme={theme}
-                maxLabelDimmension={maxLabelDimmension}
+                maxLabelDimension={maxLabelDimension}
                 {...chartProps}
               />
             </div>
@@ -607,8 +604,21 @@ const ChartFactory = React.memo(
               width={width}
               data={!isComparison ? primaryData : [primaryData, comparisonData]}
               parts={{
+                axis: {
+                  independent: {
+                    // Line charts are for time-series and it's OK not show all
+                    // labels on axis e.g. 2000, 2005 instead of
+                    // 2000, 2001, 2002, 2003, 2004, 2005
+                    // NOTE: This works for numbers only!
+                    fixLabelOverlap: true,
+                    // To support non-numbers, lets hard-limit to 5 ticks
+                    // TODO(kilemensi): Find a way to make this a theme config per charts type
+                    tickCount: 5
+                  }
+                },
                 container: {
-                  labels: ({ datum }) => `y: ${format(datum.y)}`
+                  labels: ({ datum }) =>
+                    datum.tooltip || `y: ${format(datum.y)}`
                 },
                 scatter: { size: 5 }
               }}

--- a/packages/charts/src/ChartFactory.js
+++ b/packages/charts/src/ChartFactory.js
@@ -122,7 +122,13 @@ const ChartFactory = React.memo(
     );
 
     const primaryData = useMemo(() => {
-      const labels = ({ x, y }, separator = ': ') => {
+      const labels = (
+        { label: dataLabel, tooltip, x, y },
+        separator = ': '
+      ) => {
+        if (dataLabel || tooltip) {
+          return dataLabel || tooltip;
+        }
         const formattedX = x ? `${x}${separator}` : '';
         return `${formattedX}${format(y)}`;
       };
@@ -514,7 +520,7 @@ const ChartFactory = React.memo(
                 height={height}
                 horizontal={showHorizontal}
                 domainPadding={domainPadding}
-                labels={({ datum }) => datum.tooltip || format(datum.y)}
+                labels={({ datum }) => datum.label || format(datum.y)}
                 padding={paddingProp}
                 theme={theme}
                 maxLabelDimension={maxLabelDimension}
@@ -551,7 +557,7 @@ const ChartFactory = React.memo(
                   width={width}
                   horizontal={showHorizontal}
                   domainPadding={domainPadding}
-                  labels={({ datum }) => datum.tooltip || format(datum.y)}
+                  labels={({ datum }) => datum.label || format(datum.y)}
                   theme={theme}
                   maxLabelDimension={maxLabelDimension}
                   {...chartProps}
@@ -569,7 +575,7 @@ const ChartFactory = React.memo(
                 width={width}
                 horizontal={showHorizontal}
                 domainPadding={domainPadding}
-                labels={({ datum }) => datum.tooltip || format(datum.y)}
+                labels={({ datum }) => datum.label || format(datum.y)}
                 theme={theme}
                 maxLabelDimension={maxLabelDimension}
                 {...chartProps}

--- a/packages/charts/src/LegendLabel.js
+++ b/packages/charts/src/LegendLabel.js
@@ -15,26 +15,20 @@ import Label from './Label';
  */
 // while we need `width` for the label, we don't need it for tooltip
 function LegendLabel({ width, ...props }) {
-  const { colorScale, datum, index, text: textProp } = props;
-  let text = textProp;
-  if (datum) {
-    const { tooltip } = datum;
-    if (tooltip) {
-      text = tooltip;
-    } else if (datum.y) {
-      text = labels(datum);
-    }
-  }
+  const { colorScale, datum, index } = props;
+  const { description } = datum || {};
 
   return (
     <g>
       <Label width={width} {...props} />
-      <VictoryTooltip
-        {...props}
-        datum={{ _x: index + 1, ...datum }}
-        text={text}
-        labelComponent={<Label colorScale={colorScale} />}
-      />
+      {description && description.length ? (
+        <VictoryTooltip
+          {...props}
+          datum={{ _x: index + 1, ...datum }}
+          text={description}
+          labelComponent={<Label colorScale={colorScale} />}
+        />
+      ) : null}
     </g>
   );
 }
@@ -44,7 +38,7 @@ LegendLabel.defaultEvents = VictoryTooltip.defaultEvents;
 LegendLabel.propTypes = {
   colorScale: propTypes.colorScale,
   datum: PropTypes.shape({
-    tooltip: PropTypes.string,
+    description: PropTypes.string,
     y: PropTypes.number
   }),
   index: PropTypes.number,

--- a/packages/charts/src/LineChart.js
+++ b/packages/charts/src/LineChart.js
@@ -9,7 +9,7 @@ import {
   VictoryVoronoiContainer
 } from 'victory';
 
-import { getLegendProps } from './utils';
+import { extractLegendData, getLegendProps } from './utils';
 import withVictoryTheme from './styles/withVictoryTheme';
 import Chart, { toChartAxisProps } from './Chart';
 import LegendLabel from './LegendLabel';
@@ -74,7 +74,7 @@ function LineChart({
   const { padding, legend } = getLegendProps(
     { height, width },
     initialLegendProps,
-    groupData[0],
+    extractLegendData(groupData),
     originalPadding
   );
 

--- a/packages/charts/src/PieChart/DonutTooltip.js
+++ b/packages/charts/src/PieChart/DonutTooltip.js
@@ -12,6 +12,8 @@ import Tooltip from './Tooltip';
 function DonutTooltip({
   center,
   cornerRadius,
+  flyoutHeight,
+  flyoutWidth,
   highlightIndex,
   highlightStyle,
   width,
@@ -32,9 +34,9 @@ function DonutTooltip({
         orientation="top"
         cornerRadius={cornerRadius}
         datum={datum}
-        flyoutHeight={width}
+        flyoutHeight={flyoutHeight}
         flyoutStyle={{ fill: 'white', stroke: 'none' }}
-        flyoutWidth={width}
+        flyoutWidth={flyoutWidth}
         labelComponent={
           <Label
             {...props}
@@ -62,6 +64,8 @@ DonutTooltip.propTypes = {
   }),
   cornerRadius: PropTypes.number,
   datum: PropTypes.shape({}),
+  flyoutHeight: PropTypes.number,
+  flyoutWidth: PropTypes.number,
   highlightIndex: PropTypes.number,
   highlightStyle: PropTypes.shape({}),
   text: PropTypes.string,
@@ -73,6 +77,8 @@ DonutTooltip.propTypes = {
 DonutTooltip.defaultProps = {
   cornerRadius: undefined,
   datum: undefined,
+  flyoutHeight: undefined,
+  flyoutWidth: undefined,
   highlightIndex: undefined,
   highlightStyle: undefined,
   center: undefined,

--- a/packages/charts/src/PieChart/index.js
+++ b/packages/charts/src/PieChart/index.js
@@ -138,6 +138,7 @@ function PieChart({
     ...donutLabelStyle,
     ...tooltipProps.style
   };
+
   // We define tooltip for donut label component here than using a separate
   // due to svg rendering components in the provided order and we don't have
   // z-index property to reorder them.
@@ -146,11 +147,13 @@ function PieChart({
       {...tooltipProps}
       colorScale={colorScale}
       cornerRadius={chartInnerRadius}
+      flyoutHeight={chartInnerRadius * 2}
+      flyoutWidth={chartInnerRadius * 2}
       highlightIndex={chart.donutHighlightIndex}
       highlightStyle={chart.donutHighlightStyle}
       center={{ ...origin }}
       style={tooltipStyle}
-      width={chartInnerRadius * 2}
+      width={chartInnerRadius * chart.donutLabelRadiusRatio * 2}
     />
   ) : (
     <Tooltip
@@ -216,7 +219,7 @@ function PieChart({
                 donutLabelData[donutLabelKey.columnIndex || 0].donutLabel ||
                 donutLabelData[donutLabelKey.columnIndex || 0].label
               }
-              width={chartInnerRadius * 2}
+              width={chartInnerRadius * chart.donutLabelRadiusRatio * 2}
               x={origin.x}
               y={origin.y}
             />

--- a/packages/charts/src/WrapLabel/wrapSVGText.js
+++ b/packages/charts/src/WrapLabel/wrapSVGText.js
@@ -1,4 +1,4 @@
-export function computeMaxLabelDimmension({ labelWidth, texts }) {
+export function computeMaxLabelDimension({ labelWidth, texts }) {
   let maxLabelWidth = labelWidth;
   let maxLabelHeight = 0;
 

--- a/packages/charts/src/styles/createVictoryTheme.js
+++ b/packages/charts/src/styles/createVictoryTheme.js
@@ -151,6 +151,7 @@ export default function createVictoryTheme(chartOptions) {
     // Default VictoryTheme.material font size is 12
     // see: https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/victory-theme/material.js
     donutHighlightStyle: { fontWeight: 'bold', fontSize: 18 },
+    donutLabelRadiusRatio: 0.75,
     donutRatio: 0.6,
     emphasisCoefficient: 0.15,
     groupSpacing: 4,

--- a/packages/charts/src/utils.js
+++ b/packages/charts/src/utils.js
@@ -1,3 +1,32 @@
+/**
+ * `groupedData` supplied to any of Bar or Line chart is in the following form:
+ * ```
+ * [
+ *  [group0bar0, group1bar0, group2bar0, ...etc],
+ *  [group0bar1, group1bar1, group2bar1, ...etc],
+ *  [group0bar2, group1bar2, group2bar2, ...etc],
+ *  ...etc
+ * ]
+ * ```
+ * The required legend data, name and (optional) description, is found in
+ * `bar0`, `bar1`, `bar2`, variables.
+ */
+export function extractLegendData(groupedData) {
+  if (
+    !groupedData ||
+    !groupedData.length ||
+    !groupedData[0].length ||
+    !groupedData[0][0].name
+  ) {
+    return undefined;
+  }
+  if (groupedData.length === 1) {
+    return groupedData;
+  }
+  // Pick first element from each row of data
+  return groupedData.map(gD => gD[0]);
+}
+
 export function getLegendProps(
   { height, width },
   initialLegendProps,

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -280,14 +280,14 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
             {
               x: 'Place to Wash Hands',
               y: 22,
-              donutLabel: 'Nono Place to Wash Hands\n22%',
-              name: 'Female'
+              donutLabel: 'Place to Wash Hands\n22%',
+              name: 'Place to Wash Hands'
             },
             {
               x: 'No Place to Wash Hands',
               y: 78,
-              donutLabel: 'No Place nyau nyau to Wash Hands\n78%',
-              name: 'Male'
+              donutLabel: 'No Place to Wash Hands\n78%',
+              name: 'No Place to Wash Hands'
             }
           ])}
           donut={boolean('donut', true)}

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -209,22 +209,18 @@ storiesOf('HURUmap UI|Charts/LineChart', module)
       <LineChart
         data={object('data', [
           [
-            { x: 1, y: 3, geo: 'Dar es Salaam' },
-            { x: 2, y: 1, geo: 'Dar es Salaam' },
-            { x: 3, y: 2, geo: 'Dar es Salaam' },
-            { x: 4, y: -2, geo: 'Dar es Salaam' },
-            { x: 5, y: -1, geo: 'Dar es Salaam' },
-            { x: 6, y: 2, geo: 'Dar es Salaam' },
-            { x: 7, y: 3, geo: 'Dar es Salaam' }
+            { x: '2013', y: 2, geo: 'Dar es Salaam' },
+            { x: '2014', y: -2, geo: 'Dar es Salaam' },
+            { x: '2015', y: -1, geo: 'Dar es Salaam' },
+            { x: '2016', y: 2, geo: 'Dar es Salaam' },
+            { x: '2017', y: 3, geo: 'Dar es Salaam' }
           ],
           [
-            { x: 1, y: -3, geo: 'Kagera' },
-            { x: 2, y: 5, geo: 'Kagera' },
-            { x: 3, y: 3, geo: 'Kagera' },
-            { x: 4, y: 0, geo: 'Kagera' },
-            { x: 5, y: -2, geo: 'Kagera' },
-            { x: 6, y: -2, geo: 'Kagera' },
-            { x: 7, y: 5, geo: 'Kagera' }
+            { x: '2013', y: 3, geo: 'Kagera' },
+            { x: '2014', y: 0, geo: 'Kagera' },
+            { x: '2015', y: -2, geo: 'Kagera' },
+            { x: '2016', y: -2, geo: 'Kagera' },
+            { x: '2017', y: 5, geo: 'Kagera' }
           ]
         ])}
         parts={{
@@ -234,24 +230,12 @@ storiesOf('HURUmap UI|Charts/LineChart', module)
           legend: {
             data: [
               {
-                name: 'A',
-                description: 'A\n \nDar es Salaam 6\n \nKagera 3'
+                name: 'Male',
+                description: 'Male\n \nDar es Salaam vs Kagera'
               },
               {
-                name: 'B',
-                description: 'B\n \nDar es Salaam 1\n \nKagera 1'
-              },
-              {
-                name: 'C',
-                description: 'C\n \nDar es Salaam 3\n \nKagera 2'
-              },
-              {
-                name: 'D',
-                description: 'D\n \nDar es Salaam 1\n \nKagera 2'
-              },
-              {
-                name: 'E',
-                description: 'E\n \nDar es Salaam 12\n \nKagera 5'
+                name: 'Female',
+                description: 'Female\n \nDar es Salaam vs Kagera'
               }
             ],
             x: number('Legend x', 90)

--- a/stories/chart.stories.js
+++ b/stories/chart.stories.js
@@ -235,23 +235,23 @@ storiesOf('HURUmap UI|Charts/LineChart', module)
             data: [
               {
                 name: 'A',
-                tooltip: 'A\n \nDar es Salaam 6\n \nKagera 3'
+                description: 'A\n \nDar es Salaam 6\n \nKagera 3'
               },
               {
                 name: 'B',
-                tooltip: 'B\n \nDar es Salaam 1\n \nKagera 1'
+                description: 'B\n \nDar es Salaam 1\n \nKagera 1'
               },
               {
                 name: 'C',
-                tooltip: 'C\n \nDar es Salaam 3\n \nKagera 2'
+                description: 'C\n \nDar es Salaam 3\n \nKagera 2'
               },
               {
                 name: 'D',
-                tooltip: 'D\n \nDar es Salaam 1\n \nKagera 2'
+                description: 'D\n \nDar es Salaam 1\n \nKagera 2'
               },
               {
                 name: 'E',
-                tooltip: 'E\n \nDar es Salaam 12\n \nKagera 5'
+                description: 'E\n \nDar es Salaam 12\n \nKagera 5'
               }
             ],
             x: number('Legend x', 90)
@@ -278,15 +278,15 @@ storiesOf('HURUmap UI|Charts/PieChart', module)
         <PieChart
           data={object('data', [
             {
-              x: 'Female',
+              x: 'Place to Wash Hands',
               y: 22,
-              donutLabel: 'Female\n22%',
+              donutLabel: 'Nono Place to Wash Hands\n22%',
               name: 'Female'
             },
             {
-              x: 'Male',
+              x: 'No Place to Wash Hands',
               y: 78,
-              donutLabel: 'Male\n78%',
+              donutLabel: 'No Place nyau nyau to Wash Hands\n78%',
               name: 'Male'
             }
           ])}

--- a/stories/factory.stories.js
+++ b/stories/factory.stories.js
@@ -76,7 +76,7 @@ storiesOf('HURUmap UI|Charts/ChartFactory', module)
     const disableShowMore =
       ['grouped_column', 'line'].includes(type) &&
       boolean('disableShowMore', true);
-    const groupsCount = Array(number('groups', 2)).fill(null);
+    const groupsCount = Array(number('groups', 3)).fill(null);
     const dataCount = Array(number('data', 2)).fill(null);
     const aggregate = select(
       'aggregate',
@@ -102,8 +102,7 @@ storiesOf('HURUmap UI|Charts/ChartFactory', module)
           const y = rand();
 
           const d = {
-            groupBy: `${dataIndex + 1}`,
-            tooltip: `D${groupIndex + 1}: ${y}\n${x}`,
+            groupBy: `G${groupIndex + 1}`,
             x,
             y
           };

--- a/stories/factory.stories.js
+++ b/stories/factory.stories.js
@@ -67,12 +67,17 @@ storiesOf('HURUmap UI|Charts/ChartFactory', module)
     );
   })
   .add('Grouped', () => {
-    const type = select('type', ['grouped_column', 'number'], 'grouped_column');
+    const type = select(
+      'type',
+      ['grouped_column', 'line', 'number'],
+      'grouped_column'
+    );
     const horizontal = boolean('horizontal');
     const disableShowMore =
-      type === 'grouped_column' && boolean('disableShowMore', true);
-    const groups = number('groups', 2);
-    const data = Array(number('data', 2) * groups).fill(null);
+      ['grouped_column', 'line'].includes(type) &&
+      boolean('disableShowMore', true);
+    const groupsCount = Array(number('groups', 2)).fill(null);
+    const dataCount = Array(number('data', 2)).fill(null);
     const aggregate = select(
       'aggregate',
       ['sum', 'avg', 'sum:percent', ''],
@@ -90,6 +95,22 @@ storiesOf('HURUmap UI|Charts/ChartFactory', module)
       aggregate: 'sum:percent',
       unique: true
     });
+    const data = dataCount
+      .map((_d, dataIndex) =>
+        groupsCount.map((_g, groupIndex) => {
+          const x = `D${dataIndex + 1}`;
+          const y = rand();
+
+          const d = {
+            groupBy: `${dataIndex + 1}`,
+            tooltip: `D${groupIndex + 1}: ${y}\n${x}`,
+            x,
+            y
+          };
+          return d;
+        })
+      )
+      .reduce((a, b) => a.concat(b));
 
     return (
       <ChartFactory
@@ -106,15 +127,7 @@ storiesOf('HURUmap UI|Charts/ChartFactory', module)
           statistic
         }}
         disableShowMore={disableShowMore}
-        data={data.map((_, index) => {
-          const y = rand();
-          return {
-            groupBy: `Group ${index % groups}`,
-            tooltip: `Group ${index % groups} Data ${index}`,
-            x: `Group ${index % groups} Data ${index}`,
-            y
-          };
-        })}
+        data={data}
       />
     );
   })


### PR DESCRIPTION
## Description

Enables legend by default for grouped data based charts (`Bar` and `Line`). It also updates the `ChartFactory` to respect label or tooltip when present in a data point instead of always creating new ones

### Minor

`donutLabelRadiusRatio` is also introduced as `Pie` chart theme option to control how much of donut radius is used by label. Currently, all of it (`1.0`) was being used causing issues when labels was broken down into multiple lines i.e. lines at the top should not use the whole radius since a circle is not as wide near the top as in the middle.

Delivers #172160825

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Peek 2020-04-04 21-35](https://user-images.githubusercontent.com/1779590/78524945-342c8780-77de-11ea-9b8e-75ea0324d0ec.gif)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation