### PR TITLE
[Hotfix] Enable PDF.js worker

### DIFF
--- a/packages/core/src/PDFDataContainer.js
+++ b/packages/core/src/PDFDataContainer.js
@@ -4,9 +4,11 @@ import { PropTypes } from 'prop-types';
 import { ButtonBase, Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
-import { Document, Page } from 'react-pdf';
+import { Document, Page, pdfjs } from 'react-pdf';
 import LeftArrow from './assets/icons/left-arrow.svg';
 import RightArrow from './assets/icons/right-arrow.svg';
+
+pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
 const useStyles = makeStyles(theme => ({
   root: {


### PR DESCRIPTION
## Description

It is crucial for performance to use PDF.js worker whenever possible. This ensures that PDF files will be rendered in a separate thread without affecting page performance.

This PR adds external `pdf.worker.js`.

Fixes ##172242441

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

### Enabled PDF Worker

![Screenshot from 2020-04-09 13-28-45](https://user-images.githubusercontent.com/1779590/78886499-fe4e0400-7a66-11ea-9278-2fafacd7ae8b.png)

### Current implementation

![Screenshot from 2020-04-09 13-27-50](https://user-images.githubusercontent.com/1779590/78886540-0f971080-7a67-11ea-9857-47a2fa591902.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation