### PR TITLE
[HotFix] Wrong scoreField in buildGeoIndexQuery

### DIFF
--- a/packages/core/src/useGeoIndexLoader/index.js
+++ b/packages/core/src/useGeoIndexLoader/index.js
@@ -20,12 +20,7 @@ export default ({ indexTable, indexField, countryCode, scoreField }) => {
             geoIndex: { nodes: indeces },
           },
         } = await client.query({
-          query: buildGeoIndexQuery(
-            indexTable,
-            indexField,
-            countryCode,
-            scoreField
-          ),
+          query: buildGeoIndexQuery(indexTable, indexField, scoreField),
           variables: { countryCode },
         });
         setIndexMapping({


### PR DESCRIPTION
## Description

`countryCode` was being passed instead of `scoreField`. This PR fixes that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation