### PR TITLE
[HotFix] ChartFactory NumberVisuals description

### DIFF
--- a/packages/charts/src/ChartFactory.js
+++ b/packages/charts/src/ChartFactory.js
@@ -524,7 +524,7 @@ const ChartFactory = React.memo(
               key={key}
               subtitle={subtitle}
               statistic={dataStatY}
-              description={`${description} ${xDesc}`}
+              description={(description && `${description} ${xDesc}`) || xDesc}
               comparisonData={[]} // TODO: pending NumberVisuals components (HURUmap-UI) fix on this propTypes
               classes={{}} // TODO: pending NumberVisuals style configurations - update root margin
               {...chartProps}

--- a/packages/charts/src/NumberVisuals.js
+++ b/packages/charts/src/NumberVisuals.js
@@ -86,9 +86,9 @@ function NumberVisuals({
       </div>
       <Typography className={classes.description}>{description}</Typography>
 
-      <List className={classes.list}>
-        {comparisonData &&
-          comparisonData.map((d) => (
+      {comparisonData && (
+        <List className={classes.list}>
+          {comparisonData.map((d) => (
             <ListItem className={classes.listParent} key={d.id}>
               <ListItemText
                 primary={
@@ -109,7 +109,8 @@ function NumberVisuals({
               />
             </ListItem>
           ))}
-      </List>
+        </List>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

`ChartFactory` should check if `description` has a value before including it `NumberVisuals` description field since `${descrption}` = `"undefined"` if description is `undefined`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation